### PR TITLE
Limit config file traversal

### DIFF
--- a/bin/cli/utils/file-utils.ts
+++ b/bin/cli/utils/file-utils.ts
@@ -1,4 +1,5 @@
 import { stat } from "node:fs/promises";
+import { homedir } from "node:os";
 import { join, resolve } from "node:path";
 
 /** File system utilities */
@@ -13,16 +14,33 @@ export async function pathExists(path: string): Promise<boolean> {
   }
 }
 
-/** Find config file in current directory or walk up parent directories */
+/**
+ * Find config file in current directory or walk up parent directories
+ * Up to git root directory, home directory or system root
+ */
 export async function findConfigFile(fileName: string, startDir: string = process.cwd()): Promise<string | null> {
   let currentDir = resolve(startDir);
   const root = resolve("/");
+  const home = resolve(homedir());
 
   while (true) {
     const configPath = join(currentDir, fileName);
     if (await pathExists(configPath)) {
       return configPath;
     }
+
+    // Stop at git project root
+    const gitPath = join(currentDir, ".git");
+    if (await pathExists(gitPath)) {
+      break;
+    }
+
+    // Stop at home directory
+    if (currentDir === home) {
+      break;
+    }
+
+    // Stop at root
     if (currentDir === root) {
       break;
     }


### PR DESCRIPTION
Resolves: #41

- finishes looking for file in git project root direcotry
- or if git not set, finish in home directory
- or if we are already outisde home directory, finish at root level

