### PR TITLE
Add OIDC verification required fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
   "description": "JAM development tooling",
   "author": "Fluffy Labs",
   "license": "MPL-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/FluffyLabs/jammin"
+  },
   "type": "module",
   "main": "./bin/cli/dist/index.js",
   "bin": {

--- a/packages/jammin-sdk/package.json
+++ b/packages/jammin-sdk/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@fluffylabs/jammin-sdk",
   "version": "0.0.2",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/FluffyLabs/jammin"
+  },
   "main": "./dist/index.js",
   "devDependencies": {
     "@tsconfig/node20": "^20.1.8",


### PR DESCRIPTION
```
Unprocessable Entity - PUT https://registry.npmjs.org/@fluffylabs%2fjammin
Error verifying sigstore provenance bundle:
Failed to validate repository information: package.json: "repository.url" is "",
expected to match "https://github.com/FluffyLabs/jammin" from provenance
``````

package.json is missing the repository field. npm's OIDC verification requires it to match the GitHub repo.
