### PR TITLE
Bump to 0.1.0

### DIFF
--- a/bin/cli/package.json
+++ b/bin/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluffylabs/jammin-cli",
-  "version": "0.0.2",
+  "version": "0.1.0",
   "description": "JAM development tooling CLI",
   "author": "Fluffy Labs",
   "license": "MPL-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluffylabs/jammin",
-  "version": "0.0.2",
+  "version": "0.1.0",
   "description": "JAM development tooling",
   "author": "Fluffy Labs",
   "license": "MPL-2.0",

--- a/packages/jammin-sdk/package.json
+++ b/packages/jammin-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluffylabs/jammin-sdk",
-  "version": "0.0.2",
+  "version": "0.1.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/FluffyLabs/jammin"


### PR DESCRIPTION
- Full pipeline support for JAM service accumulation testing
- Seamless workflow: jammin create → jammin build → jammin test
- Version bump to 0.1.0 for CLI and SDK packages
