### PR TITLE
Added support for C3 JAM SDK

### DIFF
--- a/bin/cli/src/commands/create-command.ts
+++ b/bin/cli/src/commands/create-command.ts
@@ -2,14 +2,14 @@ import * as p from "@clack/prompts";
 import { fetchRepo, updatePackageJson } from "@fluffylabs/jammin-sdk";
 import { Command, InvalidArgumentError } from "commander";
 
-type Template = "jam-sdk" | "jade" | "jambrains" | "ajanta" | "c3sdk" | "undecided";
+type Template = "jam-sdk" | "jade" | "jambrains" | "ajanta" | "jamc3" | "undecided";
 
 const TARGETS: Record<Template, string> = {
   "jam-sdk": "jammin-create/jammin-create-jam-sdk",
   jade: "jammin-create/jammin-create-jade",
   jambrains: "jammin-create/jammin-create-jambrains",
   ajanta: "jammin-create/jammin-create-ajanta",
-  c3sdk: "jammin-create/jammin-create-c3sdk",
+  jamc3: "jammin-create/jammin-create-jamc3",
   undecided: "jammin-create/jammin-create-undecided",
 };
 

--- a/bin/cli/src/commands/create-command.ts
+++ b/bin/cli/src/commands/create-command.ts
@@ -2,13 +2,14 @@ import * as p from "@clack/prompts";
 import { fetchRepo, updatePackageJson } from "@fluffylabs/jammin-sdk";
 import { Command, InvalidArgumentError } from "commander";
 
-type Template = "jam-sdk" | "jade" | "jambrains" | "ajanta" | "undecided";
+type Template = "jam-sdk" | "jade" | "jambrains" | "ajanta" | "c3sdk" | "undecided";
 
 const TARGETS: Record<Template, string> = {
   "jam-sdk": "jammin-create/jammin-create-jam-sdk",
   jade: "jammin-create/jammin-create-jade",
   jambrains: "jammin-create/jammin-create-jambrains",
   ajanta: "jammin-create/jammin-create-ajanta",
+  c3sdk: "jammin-create/jammin-create-c3sdk",
   undecided: "jammin-create/jammin-create-undecided",
 };
 

--- a/packages/jammin-sdk/config/sdk-configs.ts
+++ b/packages/jammin-sdk/config/sdk-configs.ts
@@ -22,8 +22,8 @@ export const SDK_CONFIGS = {
     build: "ajanta build main.py -o service.jam",
     test: "true",
   },
-  "c3sdk-1.0.2": {
-    image: "ghcr.io/dreverr/jamsdk:1.0.2",
+  "jamc3-1.1.1": {
+    image: "ghcr.io/dreverr/jamc3:1.1.1",
     build: "main.c3 -o service.jam",
     test: "bun test",
   },

--- a/packages/jammin-sdk/config/sdk-configs.ts
+++ b/packages/jammin-sdk/config/sdk-configs.ts
@@ -26,5 +26,5 @@ export const SDK_CONFIGS = {
     image: "ghcr.io/dreverr/jamsdk:1.0.2",
     build: "main.c3 -o service.jam",
     test: "bun test",
-  }
+  },
 } as const satisfies Record<string, SdkConfig>;

--- a/packages/jammin-sdk/config/sdk-configs.ts
+++ b/packages/jammin-sdk/config/sdk-configs.ts
@@ -22,4 +22,9 @@ export const SDK_CONFIGS = {
     build: "ajanta build main.py -o service.jam",
     test: "true",
   },
+  "c3sdk-1.0.2": {
+    image: "ghcr.io/dreverr/jamsdk:1.0.2",
+    build: "main.c3 -o service.jam",
+    test: "bun test",
+  }
 } as const satisfies Record<string, SdkConfig>;

--- a/packages/jammin-sdk/config/sdk-configs.ts
+++ b/packages/jammin-sdk/config/sdk-configs.ts
@@ -22,8 +22,8 @@ export const SDK_CONFIGS = {
     build: "ajanta build main.py -o service.jam",
     test: "true",
   },
-  "jamc3-1.1.1": {
-    image: "ghcr.io/dreverr/jamc3:1.1.1",
+  "jamc3-1.1.2": {
+    image: "ghcr.io/dreverr/jamc3:1.1.2",
     build: "main.c3 -o service.jam",
     test: "bun test",
   },


### PR DESCRIPTION
## Add C3 JAM SDK (`jamsdk`)

Adding C3 as a new SDK option for building JAM services and authorizers via [`jamc3`](https://github.com/DrEverr/jamc3).

### Why a new SDK?

The other SDKs are built with their own scope and priorities, which is fine, but I wanted something I fully own end-to-end, designed the way I think a JAM SDK should work. On top of that, I've been getting into C3 and it turns out to be a really nice fit for this kind of work:

- **No runtime, no GC.** C3 compiles straight to native code with zero implicit allocations — exactly what you want when targeting PolkaVM, without writing actual C.
- **Cross-compiling to RISC-V.** `c3c` has first-class `rv64imac` support with no-stdlib/no-libc out of the box. No toolchain wrestling.
- **Native C ABI.** Host function bindings are clean `extern fn` declarations — no FFI wrappers, no unsafe blocks. All 27 host calls are one-liners.
- **Tiny blobs.** No hidden runtime means `.jam` output is small and deterministic. Every byte counts on-chain.
- **Modern where it matters.** Optional types, faults, defer, modules, slices — safety without the compile-time tax or binary bloat.

### What's in the box

- Full SDK library (`jamc3.c3l`) — all 27 host functions, Gray Paper types, high-level service/storage APIs, Appendix C codecs
- Entry point dispatch for services (`refine` + `accumulate`) and authorizers (`is_authorized`)
- Build pipeline: C3 → RISC-V → ELF → `.polkavm` → `.jam`
- Patched `polkavm-to-jam` converter (works with polkatool 0.29+)
- Docker image with everything bundled: `ghcr.io/dreverr/jamc3`
- Four examples: hello-world, storage-demo, simple-auth, fibonacci

### Links

- https://github.com/DrEverr/jamc3
- https://github.com/DrEverr/jamc3.c3l
- https://c3-lang.org/
