### PR TITLE
Add release-prepare workflow

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -1,0 +1,141 @@
+name: Prepare release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Target version (semver, with or without v prefix). Pre-releases like 0.2.0-rc.1 are allowed."
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: release-prepare
+  cancel-in-progress: false
+
+env:
+  BUN_VERSION: 1.3.3
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+
+      - name: Validate and normalize version
+        id: ver
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          VERSION="${INPUT_VERSION#v}"
+          SEMVER_REGEX='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*))*))?(\+([0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*))?$'
+          if [[ ! "$VERSION" =~ $SEMVER_REGEX ]]; then
+            echo "Error: '$INPUT_VERSION' is not a valid semver version" >&2
+            exit 1
+          fi
+          TAG="v${VERSION}"
+          BRANCH="release/${TAG}"
+          {
+            echo "version=${VERSION}"
+            echo "tag=${TAG}"
+            echo "branch=${BRANCH}"
+          } >> "$GITHUB_OUTPUT"
+          echo "Normalized: tag=${TAG}, branch=${BRANCH}"
+
+      - name: Pre-flight checks
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BRANCH: ${{ steps.ver.outputs.branch }}
+          TAG: ${{ steps.ver.outputs.tag }}
+        run: |
+          if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+            echo "Error: branch '$BRANCH' already exists on origin" >&2
+            exit 1
+          fi
+          if git ls-remote --exit-code --tags origin "$TAG" >/dev/null 2>&1; then
+            echo "Error: tag '$TAG' already exists on origin" >&2
+            exit 1
+          fi
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Error: release '$TAG' already exists" >&2
+            exit 1
+          fi
+
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Create release branch
+        env:
+          BRANCH: ${{ steps.ver.outputs.branch }}
+        run: git switch -c "$BRANCH"
+
+      - name: Bump versions
+        env:
+          VERSION: ${{ steps.ver.outputs.version }}
+        run: |
+          bun pm pkg set version="$VERSION"
+          (cd bin/cli && bun pm pkg set version="$VERSION")
+          (cd packages/jammin-sdk && bun pm pkg set version="$VERSION")
+
+      - name: Commit and push
+        env:
+          TAG: ${{ steps.ver.outputs.tag }}
+          BRANCH: ${{ steps.ver.outputs.branch }}
+        run: |
+          git add package.json bin/cli/package.json packages/jammin-sdk/package.json
+          git commit -m "chore(release): bump version to ${TAG}"
+          git push origin "$BRANCH"
+
+      - name: Create draft release
+        id: release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.ver.outputs.tag }}
+        run: |
+          RELEASE_URL=$(gh release create "$TAG" \
+            --draft \
+            --title "$TAG" \
+            --notes "")
+          echo "url=${RELEASE_URL}" >> "$GITHUB_OUTPUT"
+
+      - name: Open PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.ver.outputs.tag }}
+          BRANCH: ${{ steps.ver.outputs.branch }}
+          RELEASE_URL: ${{ steps.release.outputs.url }}
+        run: |
+          cat > /tmp/pr_body.md <<EOF
+          Prepares release **${TAG}**.
+
+          Bumps the version of:
+          - \`@fluffylabs/jammin\`
+          - \`@fluffylabs/jammin-cli\`
+          - \`@fluffylabs/jammin-sdk\`
+
+          ## Next steps
+
+          1. Review and merge this PR.
+          2. Publish the draft release: ${RELEASE_URL}
+
+          Publishing the release will trigger the npm publish workflows.
+          EOF
+          gh pr create \
+            --base main \
+            --head "$BRANCH" \
+            --title "chore(release): ${TAG}" \
+            --body-file /tmp/pr_body.md

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -68,8 +68,15 @@ jobs:
             echo "Error: tag '$TAG' already exists on origin" >&2
             exit 1
           fi
-          if gh release view "$TAG" >/dev/null 2>&1; then
+          set +e
+          gh release view "$TAG" >/dev/null 2>&1
+          rc=$?
+          set -e
+          if [ "$rc" -eq 0 ]; then
             echo "Error: release '$TAG' already exists" >&2
+            exit 1
+          elif [ "$rc" -ne 1 ]; then
+            echo "Error: failed to check release '$TAG' (gh exit code: $rc)" >&2
             exit 1
           fi
 
@@ -97,6 +104,10 @@ jobs:
           BRANCH: ${{ steps.ver.outputs.branch }}
         run: |
           git add package.json bin/cli/package.json packages/jammin-sdk/package.json
+          if git diff --cached --quiet; then
+            echo "Error: no version changes to commit; package versions may already be ${TAG}" >&2
+            exit 1
+          fi
           git commit -m "chore(release): bump version to ${TAG}"
           git push origin "$BRANCH"
 


### PR DESCRIPTION
## Summary

Adds `.github/workflows/release-prepare.yml`, a manually-triggered workflow that prepares a release end-to-end:

- Takes a `version` input (e.g., `0.2.0` or `v0.2.0`, with or without leading `v`; pre-releases like `0.2.0-rc.1` are accepted).
- Validates the input against the official semver regex.
- Pre-flight checks that the target branch, tag, and draft release don't already exist.
- Bumps the version of `@fluffylabs/jammin`, `@fluffylabs/jammin-cli`, and `@fluffylabs/jammin-sdk` via `bun pm pkg set`.
- Commits to a new `release/v<version>` branch, pushes, and opens a PR against `main`.
- Creates a draft GitHub release with `tag_name=v<version>`.

Once the maintainer merges the PR and then publishes the draft release, the existing `publish-npm-cli.yml` and `publish-npm-sdk.yml` workflows fire on `release: published` and ship the artifacts to npm.

## Test plan

- [ ] Merge this PR.
- [ ] Trigger `Release - Prepare` manually with `version=0.1.1-test.1` (or similar).
- [ ] Verify the auto-opened PR diff shows only the three `package.json` versions changed.
- [ ] Verify a draft release `v0.1.1-test.1` exists in the Releases tab.
- [ ] Close that PR and delete the branch + draft release without merging.
- [ ] Re-run the workflow with a real release version when ready to ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)