### PR TITLE
Bump GitHub Actions to latest major versions

### DIFF
--- a/.github/workflows/build-docker-ajanta.yml
+++ b/.github/workflows/build-docker-ajanta.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Extract version
         id: image-version
@@ -23,10 +23,10 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build Docker image for testing
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           load: true
@@ -36,7 +36,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Checkout code examples
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: jammin-create/jammin-create-ajanta
           path: ajanta-example
@@ -55,7 +55,7 @@ jobs:
           docker save ajanta:${{ steps.image-version.outputs.version }} | gzip > ajanta-image.tar.gz
 
       - name: Upload Docker image artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ajanta-docker-image
           path: ajanta-image.tar.gz
@@ -63,7 +63,7 @@ jobs:
 
       - name: Log in to GitHub Container Registry
         if: github.event_name == 'push'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -71,7 +71,7 @@ jobs:
 
       - name: Build and push Docker image
         if: github.event_name == 'push'
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: true

--- a/.github/workflows/build-docker-jade.yml
+++ b/.github/workflows/build-docker-jade.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Extract version
         id: image-version
@@ -23,10 +23,10 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build Docker image for testing
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           load: true
@@ -36,7 +36,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Checkout code examples
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: tomusdrw/jam-examples
           path: jam-examples
@@ -50,7 +50,7 @@ jobs:
           docker save jade:${{ steps.image-version.outputs.version }} | gzip > jade-image.tar.gz
 
       - name: Upload Docker image artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: jade-docker-image
           path: jade-image.tar.gz
@@ -58,7 +58,7 @@ jobs:
 
       - name: Log in to GitHub Container Registry
         if: github.event_name == 'push'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -66,7 +66,7 @@ jobs:
 
       - name: Build and push Docker image
         if: github.event_name == 'push'
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: true

--- a/.github/workflows/build-docker-jam-sdk.yml
+++ b/.github/workflows/build-docker-jam-sdk.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Extract version
         id: image-version
@@ -23,10 +23,10 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build Docker image for testing
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           load: true
@@ -36,7 +36,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Checkout code examples
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: jammin-create/jammin-create-jam-sdk
           path: jam-sdk-example
@@ -50,7 +50,7 @@ jobs:
           docker save jam-sdk:${{ steps.image-version.outputs.version }} | gzip > jam-sdk-image.tar.gz
 
       - name: Upload Docker image artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: jam-sdk-docker-image
           path: jam-sdk-image.tar.gz
@@ -58,7 +58,7 @@ jobs:
 
       - name: Log in to GitHub Container Registry
         if: github.event_name == 'push'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -66,7 +66,7 @@ jobs:
 
       - name: Build and push Docker image
         if: github.event_name == 'push'
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: true

--- a/.github/workflows/build-docker-polkajam.yml
+++ b/.github/workflows/build-docker-polkajam.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Extract version
         id: image-version
@@ -23,10 +23,10 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build Docker image for testing
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           load: true
@@ -45,7 +45,7 @@ jobs:
           docker save polkajam:${{ steps.image-version.outputs.version }} | gzip > polkajam-image.tar.gz
 
       - name: Upload Docker image artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: polkajam-docker-image
           path: polkajam-image.tar.gz
@@ -53,7 +53,7 @@ jobs:
 
       - name: Log in to GitHub Container Registry
         if: github.event_name == 'push'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -61,7 +61,7 @@ jobs:
 
       - name: Build and push Docker image
         if: github.event_name == 'push'
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,15 +22,15 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install mdBook
-        uses: peaceiris/actions-mdbook@v1
+        uses: peaceiris/actions-mdbook@v2
         with:
           mdbook-version: latest
       - name: Build book
         run: mdbook build docs
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: docs/book
 
@@ -44,4 +44,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/publish-npm-cli.yml
+++ b/.github/workflows/publish-npm-cli.yml
@@ -22,15 +22,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@v2
         with:
           bun-version: ${{ env.BUN_VERSION }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/publish-npm-sdk.yml
+++ b/.github/workflows/publish-npm-sdk.yml
@@ -22,15 +22,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@v2
         with:
           bun-version: ${{ env.BUN_VERSION }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
-    - uses: oven-sh/setup-bun@v1
+    - uses: oven-sh/setup-bun@v2
       with:
         bun-version: 1.3.3
 

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -24,13 +24,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout main
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: main
           fetch-depth: 0
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@v2
         with:
           bun-version: ${{ env.BUN_VERSION }}
 


### PR DESCRIPTION
## Summary

- Upgrades every GitHub Action used across `.github/workflows/` to the latest major release.
- All bumps are major version jumps (some skip multiple majors, e.g. `upload-artifact` v4 → v7).

| Action | Before | After |
| --- | --- | --- |
| actions/checkout | v4 | v6 |
| actions/upload-artifact | v4 | v7 |
| actions/setup-node | v4 | v6 |
| actions/upload-pages-artifact | v3 | v5 |
| actions/deploy-pages | v4 | v5 |
| docker/setup-buildx-action | v3 | v4 |
| docker/build-push-action | v5 | v7 |
| docker/login-action | v3 | v4 |
| oven-sh/setup-bun | v1 | v2 |
| peaceiris/actions-mdbook | v1 | v2 |

## Things to watch

- `actions/upload-artifact@v7` requires unique artifact names per run (immutable artifacts model from v4 onward). Each docker build workflow uploads exactly once, so this should be fine.
- `docker/build-push-action@v7` enables provenance/SBOM attestations by default; pushed `ghcr.io` images will now carry attestation manifests.
- `oven-sh/setup-bun@v2` and `peaceiris/actions-mdbook@v2` still accept the existing inputs (`bun-version`, `mdbook-version`) used here.

## Test plan

- [ ] `Quality Assurance` workflow passes on this PR
- [ ] `Build - Docker - Ajanta` / `Jade` / `JAM SDK` / `polkajam` workflows pass (they trigger on PRs)
- [ ] `Docs` workflow build job passes on this PR
- [ ] After merge: confirm `release-prepare` workflow still works on the next release

🤖 Generated with [Claude Code](https://claude.com/claude-code)