### PR TITLE
Bump as-lan SDK to 0.0.5

### DIFF
--- a/bin/cli/src/commands/build-command.test.ts
+++ b/bin/cli/src/commands/build-command.test.ts
@@ -94,8 +94,8 @@ describe("build-command", () => {
       }
       const dockerCommand = spawnCall[0][2] as string;
 
-      expect(dockerCommand).toContain(SDK_CONFIGS["aslan-0.0.4"].image);
-      expect(dockerCommand).toContain(SDK_CONFIGS["aslan-0.0.4"].build);
+      expect(dockerCommand).toContain(SDK_CONFIGS["aslan-0.0.5"].image);
+      expect(dockerCommand).toContain(SDK_CONFIGS["aslan-0.0.5"].build);
       expect(dockerCommand).toContain(`${resolve("/test/project", "./services/example")}:/app`);
     });
 

--- a/bin/cli/src/commands/test-command.test.ts
+++ b/bin/cli/src/commands/test-command.test.ts
@@ -94,8 +94,8 @@ describe("test-command", () => {
       }
       const dockerCommand = spawnCall[0][2] as string;
 
-      expect(dockerCommand).toContain(SDK_CONFIGS["aslan-0.0.4"].image);
-      expect(dockerCommand).toContain(SDK_CONFIGS["aslan-0.0.4"].test);
+      expect(dockerCommand).toContain(SDK_CONFIGS["aslan-0.0.5"].image);
+      expect(dockerCommand).toContain(SDK_CONFIGS["aslan-0.0.5"].test);
       expect(dockerCommand).toContain(`${resolve("/test/project", "./services/example")}:/app`);
     });
 

--- a/docs/src/service-examples.md
+++ b/docs/src/service-examples.md
@@ -86,14 +86,14 @@ $ docker run --rm -v $(pwd):/app jade test
 The as-lan docker image ships with Node.js, `wasm-pvm`, and the AssemblyScript toolchain pre-installed. Pull it:
 
 ```console
-$ docker pull ghcr.io/tomusdrw/jammin-as-lan:0.0.4
+$ docker pull ghcr.io/tomusdrw/jammin-as-lan:0.0.5
 ```
 
 Then `cd` into the example code directory and build:
 
 ```console
 $ cd jammin-create-aslan/services/example
-$ docker run --rm -v $(pwd):/app ghcr.io/tomusdrw/jammin-as-lan:0.0.4 npm run build
+$ docker run --rm -v $(pwd):/app ghcr.io/tomusdrw/jammin-as-lan:0.0.5 npm run build
 ```
 
 The image's entrypoint symlinks the global toolchain into `/app/node_modules` if no `node_modules` already exists in the mounted directory.
@@ -101,13 +101,13 @@ The image's entrypoint symlinks the global toolchain into `/app/node_modules` if
 #### Unit tests
 
 ```console
-$ docker run --rm -v $(pwd):/app ghcr.io/tomusdrw/jammin-as-lan:0.0.4 npm test
+$ docker run --rm -v $(pwd):/app ghcr.io/tomusdrw/jammin-as-lan:0.0.5 npm test
 ```
 
 #### SDK names accepted in jammin.build.yml
 
 Any of the following resolve to the same image and commands:
 
-- `aslan-0.0.4` (canonical key in `SDK_CONFIGS`)
-- `as-lan-0.0.4` (versioned alias matching the framework's spelling)
+- `aslan-0.0.5` (canonical key in `SDK_CONFIGS`)
+- `as-lan-0.0.5` (versioned alias matching the framework's spelling)
 - `as-lan` (bare alias — follows the current default version; pin a versioned alias for reproducibility)

--- a/packages/jammin-sdk/config/config-validator.test.ts
+++ b/packages/jammin-sdk/config/config-validator.test.ts
@@ -159,19 +159,19 @@ describe("Validate Build Config", () => {
     expect(() => validateBuildConfig(config)).toThrow("SDK image is required");
   });
 
-  test("Should accept canonical aslan-0.0.4 SDK", () => {
+  test("Should accept canonical aslan-0.0.5 SDK", () => {
     const config = {
       services: [
         {
           path: "./services/example",
           name: "example",
-          sdk: "aslan-0.0.4",
+          sdk: "aslan-0.0.5",
         },
       ],
     };
 
     const result = validateBuildConfig(config);
-    expect(result.services[0]?.sdk).toBe("aslan-0.0.4");
+    expect(result.services[0]?.sdk).toBe("aslan-0.0.5");
   });
 
   test("Should accept bare 'as-lan' alias as SDK", () => {
@@ -189,19 +189,19 @@ describe("Validate Build Config", () => {
     expect(result.services[0]?.sdk).toBe("as-lan");
   });
 
-  test("Should accept versioned 'as-lan-0.0.4' alias as SDK", () => {
+  test("Should accept versioned 'as-lan-0.0.5' alias as SDK", () => {
     const config = {
       services: [
         {
           path: "./services/example",
           name: "example",
-          sdk: "as-lan-0.0.4",
+          sdk: "as-lan-0.0.5",
         },
       ],
     };
 
     const result = validateBuildConfig(config);
-    expect(result.services[0]?.sdk).toBe("as-lan-0.0.4");
+    expect(result.services[0]?.sdk).toBe("as-lan-0.0.5");
   });
 
   test("Should reject unknown 'as-lan-0.0.3' alias", () => {

--- a/packages/jammin-sdk/config/sdk-configs.test.ts
+++ b/packages/jammin-sdk/config/sdk-configs.test.ts
@@ -9,27 +9,27 @@ describe("SDK_ALIASES", () => {
     }
   });
 
-  test("Bare 'as-lan' alias resolves to aslan-0.0.4", () => {
-    expect(SDK_ALIASES["as-lan"]).toBe("aslan-0.0.4");
+  test("Bare 'as-lan' alias resolves to aslan-0.0.5", () => {
+    expect(SDK_ALIASES["as-lan"]).toBe("aslan-0.0.5");
   });
 
-  test("Versioned 'as-lan-0.0.4' alias resolves to aslan-0.0.4", () => {
-    expect(SDK_ALIASES["as-lan-0.0.4"]).toBe("aslan-0.0.4");
+  test("Versioned 'as-lan-0.0.5' alias resolves to aslan-0.0.5", () => {
+    expect(SDK_ALIASES["as-lan-0.0.5"]).toBe("aslan-0.0.5");
   });
 });
 
 describe("resolveSdkId", () => {
   test("Returns the input when it is already a canonical SDK_CONFIGS key", () => {
-    expect(resolveSdkId("aslan-0.0.4")).toBe("aslan-0.0.4");
+    expect(resolveSdkId("aslan-0.0.5")).toBe("aslan-0.0.5");
     expect(resolveSdkId("jam-sdk-0.1.26")).toBe("jam-sdk-0.1.26");
   });
 
-  test("Resolves the bare 'as-lan' alias to aslan-0.0.4", () => {
-    expect(resolveSdkId("as-lan")).toBe("aslan-0.0.4");
+  test("Resolves the bare 'as-lan' alias to aslan-0.0.5", () => {
+    expect(resolveSdkId("as-lan")).toBe("aslan-0.0.5");
   });
 
-  test("Resolves the versioned 'as-lan-0.0.4' alias to aslan-0.0.4", () => {
-    expect(resolveSdkId("as-lan-0.0.4")).toBe("aslan-0.0.4");
+  test("Resolves the versioned 'as-lan-0.0.5' alias to aslan-0.0.5", () => {
+    expect(resolveSdkId("as-lan-0.0.5")).toBe("aslan-0.0.5");
   });
 
   test("Returns undefined for unknown identifiers", () => {
@@ -58,13 +58,13 @@ describe("resolveSdkId", () => {
 
 describe("resolveSdk", () => {
   test("Returns SDK_CONFIGS entry for a canonical key", () => {
-    const result = resolveSdk("aslan-0.0.4");
-    expect(result).toBe(SDK_CONFIGS["aslan-0.0.4"]);
+    const result = resolveSdk("aslan-0.0.5");
+    expect(result).toBe(SDK_CONFIGS["aslan-0.0.5"]);
   });
 
   test("Returns SDK_CONFIGS entry for an alias key", () => {
     const result = resolveSdk("as-lan");
-    expect(result).toBe(SDK_CONFIGS["aslan-0.0.4"]);
+    expect(result).toBe(SDK_CONFIGS["aslan-0.0.5"]);
   });
 
   test("Returns the inline SdkConfig object unchanged", () => {
@@ -83,8 +83,8 @@ describe("ServiceConfig.sdk type accepts alias strings", () => {
 
   // Compile-time assertions: these fail tsc if the union narrows.
   type _AliasAccepted = Assert<"as-lan" extends ServiceConfig["sdk"] ? true : false>;
-  type _VersionedAliasAccepted = Assert<"as-lan-0.0.4" extends ServiceConfig["sdk"] ? true : false>;
-  type _CanonicalAccepted = Assert<"aslan-0.0.4" extends ServiceConfig["sdk"] ? true : false>;
+  type _VersionedAliasAccepted = Assert<"as-lan-0.0.5" extends ServiceConfig["sdk"] ? true : false>;
+  type _CanonicalAccepted = Assert<"aslan-0.0.5" extends ServiceConfig["sdk"] ? true : false>;
 
   test("Constructs a ServiceConfig literal with an alias key", () => {
     const cfg: ServiceConfig = {

--- a/packages/jammin-sdk/config/sdk-configs.ts
+++ b/packages/jammin-sdk/config/sdk-configs.ts
@@ -27,16 +27,16 @@ export const SDK_CONFIGS = {
     build: "main.c3 -o service.jam",
     test: "bun test",
   },
-  "aslan-0.0.4": {
-    image: "ghcr.io/tomusdrw/jammin-as-lan:0.0.4",
+  "aslan-0.0.5": {
+    image: "ghcr.io/tomusdrw/jammin-as-lan:0.0.5",
     build: "npm run build",
     test: "npm test",
   },
 } as const satisfies Record<string, SdkConfig>;
 
 export const SDK_ALIASES = {
-  "as-lan": "aslan-0.0.4",
-  "as-lan-0.0.4": "aslan-0.0.4",
+  "as-lan": "aslan-0.0.5",
+  "as-lan-0.0.5": "aslan-0.0.5",
 } as const satisfies Record<string, keyof typeof SDK_CONFIGS>;
 
 /**


### PR DESCRIPTION
## Summary
- Bumps the built-in `as-lan` SDK from `0.0.4` to `0.0.5` (canonical key, image tag, and `as-lan-*` versioned alias)
- Updates SDK config / validator tests and docs (`docs/src/service-examples.md`) to reference the new version

## Test plan
- [x] `bun test` (164 pass)
- [x] `bun run qa` (biome clean)
- [x] `bun run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)