### PR TITLE
Bump JAMC3 SDK to 2.0.2

### DIFF
--- a/packages/jammin-sdk/config/sdk-configs.ts
+++ b/packages/jammin-sdk/config/sdk-configs.ts
@@ -22,10 +22,10 @@ export const SDK_CONFIGS = {
     build: "ajanta build main.py -o service.jam",
     test: "true",
   },
-  "jamc3-1.1.2": {
-    image: "ghcr.io/dreverr/jamc3:1.1.2",
+  "jamc3-2.0.2": {
+    image: "ghcr.io/dreverr/jamc3:2.0.2",
     build: "main.c3 -o service.jam",
-    test: "bun test",
+    test: "echo 'No test support for JAMC3'",
   },
   "aslan-0.0.6": {
     image: "ghcr.io/tomusdrw/jammin-as-lan:0.0.6",


### PR DESCRIPTION
## Summary
- Replace `jamc3-1.1.2` with `jamc3-2.0.2` in `SDK_CONFIGS`
- The `1.1.2` image is broken at the docker daemon level (`docker pull ghcr.io/dreverr/jamc3:1.1.2` returns `manifest unknown`, even though the OCI manifest is reachable via direct HTTP). This blocks `jammin build` for any template using it.
- `2.0.2` is the latest tag from the same publisher (https://github.com/DrEverr/JAMC3/pkgs/container/jamc3) and pulls cleanly on linux/amd64.
- The `2.0.2` image no longer ships `bun`, so the previous `test: "bun test"` would fail. Replaced with `test: "echo 'No test support for JAMC3'"` since the template has no test suite anyway.

## Follow-up (not in this PR)
- Bump `jamc3` SDK id in `jammin-create/jammin-create-jamc3` and the `jamc3` service entry in `jammin-create/jammin-create-undecided` once a new jammin release ships with this change.

## Test plan
- [x] `bun run build` passes
- [x] `bun test` — 164 pass, 0 fail
- [x] `bun run qa` — biome clean
- [x] Verified `docker pull --platform=linux/amd64 ghcr.io/dreverr/jamc3:2.0.2` succeeds
- [x] Verified `docker pull ghcr.io/dreverr/jamc3:1.1.2` fails with `manifest unknown` (the bug we're fixing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)