### PR TITLE
Fix jamc3 test command to use --help

### DIFF
--- a/packages/jammin-sdk/config/sdk-configs.ts
+++ b/packages/jammin-sdk/config/sdk-configs.ts
@@ -25,7 +25,7 @@ export const SDK_CONFIGS = {
   "jamc3-2.0.2": {
     image: "ghcr.io/dreverr/jamc3:2.0.2",
     build: "main.c3 -o service.jam",
-    test: "echo 'No test support for JAMC3'",
+    test: "--help",
   },
   "aslan-0.0.6": {
     image: "ghcr.io/tomusdrw/jammin-as-lan:0.0.6",


### PR DESCRIPTION
## Summary
- Changes the `jamc3-2.0.2` SDK entry's `test` value from `"echo 'No test support for JAMC3'"` to `"--help"`.
- The previous value (introduced in #121) cannot work: jammin's test runner does `sdk.test.split(" ")` (`bin/cli/src/commands/test-command.ts:24`) and passes the result as args to the image's entrypoint, not to a shell. The jamc3 image entrypoint is `jam-build`, so the invocation became `jam-build echo No test...` which errors with `Unknown option: echo`.
- `--help` is the only single-token `jam-build` flag that exits 0 (`--version` exits 1).

## Verification
- `docker run --rm ghcr.io/dreverr/jamc3:2.0.2 --help` → exits 0 (prints jam-build help)
- `docker run --rm ghcr.io/dreverr/jamc3:2.0.2 echo foo` → exits 1 (`Unknown option: echo`)
- `bun test`: 164/164 pass
- `bun run qa`: clean

## Follow-up
- After this lands and a new jammin release ships, revert the inline-SDK workaround applied to `jammin-create/jammin-create-jamc3` and the jamc3 service in `jammin-create/jammin-create-undecided`, both of which currently use the inline SDK form to override this same value pending this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)