### PR TITLE
Wildcard SDK version entries (aslan@0.0.6)

### DIFF
--- a/bin/cli/src/commands/build-command.test.ts
+++ b/bin/cli/src/commands/build-command.test.ts
@@ -61,7 +61,7 @@ describe("build-command", () => {
       const service: ServiceConfig = {
         name: "jade-service",
         path: "./jade",
-        sdk: "jade-0.0.15-pre.1",
+        sdk: "jade@0.0.15-pre.1",
       };
 
       await callDockerBuild(service, "/test/project");
@@ -73,8 +73,8 @@ describe("build-command", () => {
       }
       const dockerCommand = spawnCall[0][2] as string;
 
-      expect(dockerCommand).toContain(SDK_CONFIGS["jade-0.0.15-pre.1"].image);
-      expect(dockerCommand).toContain(SDK_CONFIGS["jade-0.0.15-pre.1"].build);
+      expect(dockerCommand).toContain("ghcr.io/fluffylabs/jammin-jade:0.0.15-pre.1");
+      expect(dockerCommand).toContain(SDK_CONFIGS["jade@*"].build);
       expect(dockerCommand).toContain(`${resolve("/test/project", "./jade")}:/app`);
     });
 

--- a/bin/cli/src/commands/build-command.test.ts
+++ b/bin/cli/src/commands/build-command.test.ts
@@ -78,11 +78,11 @@ describe("build-command", () => {
       expect(dockerCommand).toContain(`${resolve("/test/project", "./jade")}:/app`);
     });
 
-    test("should generate correct Docker command for as-lan alias", async () => {
+    test("should generate correct Docker command for wildcard as-lan@0.0.6", async () => {
       const service: ServiceConfig = {
         name: "as-lan-service",
         path: "./services/example",
-        sdk: "as-lan",
+        sdk: "as-lan@0.0.6",
       };
 
       await callDockerBuild(service, "/test/project");
@@ -94,8 +94,8 @@ describe("build-command", () => {
       }
       const dockerCommand = spawnCall[0][2] as string;
 
-      expect(dockerCommand).toContain(SDK_CONFIGS["aslan-0.0.6"].image);
-      expect(dockerCommand).toContain(SDK_CONFIGS["aslan-0.0.6"].build);
+      expect(dockerCommand).toContain("ghcr.io/tomusdrw/jammin-as-lan:0.0.6");
+      expect(dockerCommand).toContain(SDK_CONFIGS["as-lan@*"].build);
       expect(dockerCommand).toContain(`${resolve("/test/project", "./services/example")}:/app`);
     });
 

--- a/bin/cli/src/commands/test-command.test.ts
+++ b/bin/cli/src/commands/test-command.test.ts
@@ -61,7 +61,7 @@ describe("test-command", () => {
       const service: ServiceConfig = {
         name: "jade-service",
         path: "./jade",
-        sdk: "jade-0.0.15-pre.1",
+        sdk: "jade@0.0.15-pre.1",
       };
 
       await testService(service, "/test/project");
@@ -73,8 +73,8 @@ describe("test-command", () => {
       }
       const dockerCommand = spawnCall[0][2] as string;
 
-      expect(dockerCommand).toContain(SDK_CONFIGS["jade-0.0.15-pre.1"].image);
-      expect(dockerCommand).toContain(SDK_CONFIGS["jade-0.0.15-pre.1"].test);
+      expect(dockerCommand).toContain("ghcr.io/fluffylabs/jammin-jade:0.0.15-pre.1");
+      expect(dockerCommand).toContain(SDK_CONFIGS["jade@*"].test);
       expect(dockerCommand).toContain(`${resolve("/test/project", "./jade")}:/app`);
     });
 

--- a/bin/cli/src/commands/test-command.test.ts
+++ b/bin/cli/src/commands/test-command.test.ts
@@ -78,11 +78,11 @@ describe("test-command", () => {
       expect(dockerCommand).toContain(`${resolve("/test/project", "./jade")}:/app`);
     });
 
-    test("should generate correct Docker command for as-lan alias", async () => {
+    test("should generate correct Docker command for wildcard as-lan@0.0.6", async () => {
       const service: ServiceConfig = {
         name: "as-lan-service",
         path: "./services/example",
-        sdk: "as-lan",
+        sdk: "as-lan@0.0.6",
       };
 
       await testService(service, "/test/project");
@@ -94,8 +94,8 @@ describe("test-command", () => {
       }
       const dockerCommand = spawnCall[0][2] as string;
 
-      expect(dockerCommand).toContain(SDK_CONFIGS["aslan-0.0.6"].image);
-      expect(dockerCommand).toContain(SDK_CONFIGS["aslan-0.0.6"].test);
+      expect(dockerCommand).toContain("ghcr.io/tomusdrw/jammin-as-lan:0.0.6");
+      expect(dockerCommand).toContain(SDK_CONFIGS["as-lan@*"].test);
       expect(dockerCommand).toContain(`${resolve("/test/project", "./services/example")}:/app`);
     });
 

--- a/docs/src/bootstrap/jammin-examples.md
+++ b/docs/src/bootstrap/jammin-examples.md
@@ -33,7 +33,7 @@ services:
 	- path: ./services/service a
 		name: a
 		# built-in sdk
-		sdk: jam-sdk-0.1.26
+		sdk: jam-sdk@0.1.26
 	- path: ./services/service b
 		name: serviceB
 		sdk: custom

--- a/docs/src/service-examples.md
+++ b/docs/src/service-examples.md
@@ -104,10 +104,20 @@ The image's entrypoint symlinks the global toolchain into `/app/node_modules` if
 $ docker run --rm -v $(pwd):/app ghcr.io/tomusdrw/jammin-as-lan:0.0.6 npm test
 ```
 
-#### SDK names accepted in jammin.build.yml
+#### SDK ids accepted in jammin.build.yml
 
-Any of the following resolve to the same image and commands:
+Use the `<name>@<version>` form:
 
-- `aslan-0.0.6` (canonical key in `SDK_CONFIGS`)
-- `as-lan-0.0.6` (versioned alias matching the framework's spelling)
-- `as-lan` (bare alias — follows the current default version; pin a versioned alias for reproducibility)
+- `aslan@0.0.6` (canonical wildcard)
+- `as-lan@0.0.6` (separate wildcard entry pointing at the same image)
+- `aslan@latest` — pulls the `latest` tag (not reproducible; pin a concrete version for shared projects)
+- `aslan@0.1.0-rc.1` — pre-release tags work, the version segment is passed through verbatim
+
+The version segment must match `[A-Za-z0-9._-]+` and is substituted into the
+docker image tag at resolve time.
+
+> **Deprecated**: the pinned dash-style keys (`aslan-0.0.6`, `jam-sdk-0.1.26`,
+> `jade-0.0.15-pre.1`, `ajanta-0.1.0`, `jamc3-1.1.2`) still resolve in 0.3.x but
+> emit a one-time `console.warn` and will be removed in 0.4.0. Migrate to the
+> `<name>@<version>` form. The `jambrains-1cfc41c` entry is not deprecated — it
+> is pinned by sha256 digest, not by a version tag.

--- a/packages/jammin-sdk/config/config-validator.test.ts
+++ b/packages/jammin-sdk/config/config-validator.test.ts
@@ -44,7 +44,7 @@ describe("Validate Build Config", () => {
         {
           path: "./service.ts",
           name: "invalid service!@#",
-          sdk: "jam-sdk",
+          sdk: "jam-sdk@0.1.26",
         },
       ],
     };
@@ -159,77 +159,57 @@ describe("Validate Build Config", () => {
     expect(() => validateBuildConfig(config)).toThrow("SDK image is required");
   });
 
-  test("Should accept canonical aslan-0.0.6 SDK", () => {
+  test("Should accept wildcard-versioned SDK 'aslan@0.0.6'", () => {
     const config = {
-      services: [
-        {
-          path: "./services/example",
-          name: "example",
-          sdk: "aslan-0.0.6",
-        },
-      ],
+      services: [{ path: "./services/example", name: "example", sdk: "aslan@0.0.6" }],
     };
+    const result = validateBuildConfig(config);
+    expect(result.services[0]?.sdk).toBe("aslan@0.0.6");
+  });
 
+  test("Should accept wildcard-versioned alias 'as-lan@0.0.6'", () => {
+    const config = {
+      services: [{ path: "./services/example", name: "example", sdk: "as-lan@0.0.6" }],
+    };
+    const result = validateBuildConfig(config);
+    expect(result.services[0]?.sdk).toBe("as-lan@0.0.6");
+  });
+
+  test("Should accept 'aslan@latest'", () => {
+    const config = {
+      services: [{ path: "./services/example", name: "example", sdk: "aslan@latest" }],
+    };
+    const result = validateBuildConfig(config);
+    expect(result.services[0]?.sdk).toBe("aslan@latest");
+  });
+
+  test("Should accept deprecated pinned 'aslan-0.0.6'", () => {
+    const config = {
+      services: [{ path: "./services/example", name: "example", sdk: "aslan-0.0.6" }],
+    };
     const result = validateBuildConfig(config);
     expect(result.services[0]?.sdk).toBe("aslan-0.0.6");
   });
 
-  test("Should accept bare 'as-lan' alias as SDK", () => {
+  test("Should reject bare 'aslan' (no version)", () => {
     const config = {
-      services: [
-        {
-          path: "./services/example",
-          name: "example",
-          sdk: "as-lan",
-        },
-      ],
+      services: [{ path: "./services/example", name: "example", sdk: "aslan" }],
     };
-
-    const result = validateBuildConfig(config);
-    expect(result.services[0]?.sdk).toBe("as-lan");
+    expect(() => validateBuildConfig(config)).toThrow(/Unknown SDK id/);
   });
 
-  test("Should accept versioned 'as-lan-0.0.6' alias as SDK", () => {
+  test("Should reject unknown framework 'fake@1.0.0'", () => {
     const config = {
-      services: [
-        {
-          path: "./services/example",
-          name: "example",
-          sdk: "as-lan-0.0.6",
-        },
-      ],
+      services: [{ path: "./services/example", name: "example", sdk: "fake@1.0.0" }],
     };
-
-    const result = validateBuildConfig(config);
-    expect(result.services[0]?.sdk).toBe("as-lan-0.0.6");
+    expect(() => validateBuildConfig(config)).toThrow(/Unknown SDK id/);
   });
 
-  test("Should reject unknown 'as-lan-0.0.3' alias", () => {
+  test("Should reject version with whitespace 'aslan@bad version'", () => {
     const config = {
-      services: [
-        {
-          path: "./services/example",
-          name: "example",
-          sdk: "as-lan-0.0.3",
-        },
-      ],
+      services: [{ path: "./services/example", name: "example", sdk: "aslan@bad version" }],
     };
-
-    expect(() => validateBuildConfig(config)).toThrow(/supported SDK ids|aliases/);
-  });
-
-  test("Should reject misspelt canonical 'aslan' (no version)", () => {
-    const config = {
-      services: [
-        {
-          path: "./services/example",
-          name: "example",
-          sdk: "aslan",
-        },
-      ],
-    };
-
-    expect(() => validateBuildConfig(config)).toThrow(/supported SDK ids|aliases/);
+    expect(() => validateBuildConfig(config)).toThrow(/Unknown SDK id/);
   });
 
   describe("Deployment Config Validation", () => {

--- a/packages/jammin-sdk/config/config-validator.ts
+++ b/packages/jammin-sdk/config/config-validator.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
-import { SDK_ALIASES, SDK_CONFIGS } from "./sdk-configs.js";
+import { isKnownSdkId, SDK_CONFIGS } from "./sdk-configs.js";
+import type { JamminBuildConfig, JamminNetworksConfig } from "./types/config.js";
 
 // Zod schemas for runtime validation of YAML configs
 
@@ -23,22 +24,29 @@ export const SdkConfigSchema = z.object({
   test: z.string().min(1, "Test command is required"),
 });
 
+function listSupportedIds(): string {
+  const keys = Object.keys(SDK_CONFIGS);
+  const wildcards = keys.filter((k) => k.endsWith("@*")).map((k) => k.replace("@*", "@<version>"));
+  const pinned = keys.filter((k) => !k.endsWith("@*"));
+  return `${wildcards.join(", ")} (or deprecated: ${pinned.join(", ")})`;
+}
+
 const ServiceConfigSchema = z.object({
   path: z.string().min(1, "Service path is required"),
   name: z
     .string()
     .min(1, "Service name is required")
     .regex(/^[a-zA-Z0-9_-]+$/, "Service name must contain only letters, numbers, hyphens, and underscores"),
-  sdk: z.union(
-    [
-      z.enum([
-        ...(Object.keys(SDK_CONFIGS) as (keyof typeof SDK_CONFIGS)[]),
-        ...(Object.keys(SDK_ALIASES) as (keyof typeof SDK_ALIASES)[]),
-      ]),
-      SdkConfigSchema,
-    ],
-    `Expected a valid custom SDK configuration or one of the supported SDK ids (${Object.keys(SDK_CONFIGS).join(", ")}) or aliases (${Object.keys(SDK_ALIASES).join(", ")})`,
-  ),
+  sdk: z
+    .union([z.string(), SdkConfigSchema], "Expected an SDK id string or an inline SDK configuration")
+    .superRefine((val, ctx) => {
+      if (typeof val === "string" && !isKnownSdkId(val)) {
+        ctx.addIssue({
+          code: "custom",
+          message: `Unknown SDK id '${val}'. Supported ids: ${listSupportedIds()}`,
+        });
+      }
+    }),
 });
 
 const ServiceDeploymentConfigSchema = z
@@ -169,11 +177,14 @@ export const JamminNetworksConfigSchema = z
   });
 
 /** Validate and parse build config */
-export function validateBuildConfig(data: unknown) {
-  return JamminBuildConfigSchema.parse(data);
+export function validateBuildConfig(data: unknown): JamminBuildConfig {
+  // The refine() on `sdk` guarantees the parsed string is a known SDK id,
+  // so the cast back to the precise `ServiceConfig.sdk` template-literal
+  // union is sound at runtime.
+  return JamminBuildConfigSchema.parse(data) as JamminBuildConfig;
 }
 
 /** Validate and parse networks config */
-export function validateNetworksConfig(data: unknown) {
+export function validateNetworksConfig(data: unknown): JamminNetworksConfig {
   return JamminNetworksConfigSchema.parse(data);
 }

--- a/packages/jammin-sdk/config/sdk-configs.test.ts
+++ b/packages/jammin-sdk/config/sdk-configs.test.ts
@@ -1,97 +1,185 @@
-import { describe, expect, test } from "bun:test";
-import { resolveSdk, resolveSdkId, SDK_ALIASES, SDK_CONFIGS } from "./sdk-configs.js";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { isKnownSdkId, resolveSdk, SDK_CONFIGS } from "./sdk-configs.js";
 import type { ServiceConfig } from "./types/config.js";
 
-describe("SDK_ALIASES", () => {
-  test("Every alias target points to a canonical SDK_CONFIGS key", () => {
-    for (const target of Object.values(SDK_ALIASES)) {
-      expect(Object.hasOwn(SDK_CONFIGS, target)).toBe(true);
+describe("SDK_CONFIGS wildcard invariants", () => {
+  test("Every '<name>@*' entry has '{version}' in its image template", () => {
+    for (const [key, entry] of Object.entries(SDK_CONFIGS)) {
+      if (key.endsWith("@*")) {
+        expect(entry.image).toContain("{version}");
+      }
     }
   });
 
-  test("Bare 'as-lan' alias resolves to aslan-0.0.6", () => {
-    expect(SDK_ALIASES["as-lan"]).toBe("aslan-0.0.6");
-  });
-
-  test("Versioned 'as-lan-0.0.6' alias resolves to aslan-0.0.6", () => {
-    expect(SDK_ALIASES["as-lan-0.0.6"]).toBe("aslan-0.0.6");
-  });
-});
-
-describe("resolveSdkId", () => {
-  test("Returns the input when it is already a canonical SDK_CONFIGS key", () => {
-    expect(resolveSdkId("aslan-0.0.6")).toBe("aslan-0.0.6");
-    expect(resolveSdkId("jam-sdk-0.1.26")).toBe("jam-sdk-0.1.26");
-  });
-
-  test("Resolves the bare 'as-lan' alias to aslan-0.0.6", () => {
-    expect(resolveSdkId("as-lan")).toBe("aslan-0.0.6");
-  });
-
-  test("Resolves the versioned 'as-lan-0.0.6' alias to aslan-0.0.6", () => {
-    expect(resolveSdkId("as-lan-0.0.6")).toBe("aslan-0.0.6");
-  });
-
-  test("Returns undefined for unknown identifiers", () => {
-    expect(resolveSdkId("nonsense")).toBeUndefined();
-    expect(resolveSdkId("as-lan-0.0.3")).toBeUndefined();
-    expect(resolveSdkId("aslan")).toBeUndefined();
-  });
-
-  test("Returns undefined for prototype properties (toString, constructor, etc.)", () => {
-    expect(resolveSdkId("toString")).toBeUndefined();
-    expect(resolveSdkId("constructor")).toBeUndefined();
-    expect(resolveSdkId("hasOwnProperty")).toBeUndefined();
-  });
-
-  test("Returns undefined for empty string", () => {
-    expect(resolveSdkId("")).toBeUndefined();
-  });
-
-  test("Every accepted SDK identifier (canonical or alias) is resolvable", () => {
-    const allAcceptedIds = [...Object.keys(SDK_CONFIGS), ...Object.keys(SDK_ALIASES)];
-    for (const id of allAcceptedIds) {
-      expect(resolveSdkId(id)).toBeDefined();
+  test("No entry has both a wildcard key and `deprecated: true`", () => {
+    for (const [key, entry] of Object.entries(SDK_CONFIGS)) {
+      if (key.endsWith("@*")) {
+        expect(entry.deprecated).toBeFalsy();
+      }
     }
   });
 });
 
-describe("resolveSdk", () => {
-  test("Returns SDK_CONFIGS entry for a canonical key", () => {
-    const result = resolveSdk("aslan-0.0.6");
-    expect(result).toBe(SDK_CONFIGS["aslan-0.0.6"]);
-  });
-
-  test("Returns SDK_CONFIGS entry for an alias key", () => {
-    const result = resolveSdk("as-lan");
-    expect(result).toBe(SDK_CONFIGS["aslan-0.0.6"]);
-  });
-
+describe("resolveSdk - inline SdkConfig", () => {
   test("Returns the inline SdkConfig object unchanged", () => {
     const inline = { image: "custom:1", build: "make", test: "make test" };
-    const result = resolveSdk(inline);
-    expect(result).toBe(inline);
-  });
-
-  test("Throws with a descriptive message for unknown string ids", () => {
-    expect(() => resolveSdk("nonsense")).toThrow("Unknown SDK id: 'nonsense'");
+    expect(resolveSdk(inline)).toBe(inline);
   });
 });
 
-describe("ServiceConfig.sdk type accepts alias strings", () => {
+describe("resolveSdk - wildcard substitution", () => {
+  test("Substitutes {version} in 'aslan@0.1.0'", () => {
+    const result = resolveSdk("aslan@0.1.0");
+    expect(result.image).toBe("ghcr.io/tomusdrw/jammin-as-lan:0.1.0");
+    expect(result.build).toBe("npm run build");
+    expect(result.test).toBe("npm test");
+  });
+
+  test("Substitutes {version} in 'as-lan@1.2.3' (separate wildcard entry, same template)", () => {
+    const result = resolveSdk("as-lan@1.2.3");
+    expect(result.image).toBe("ghcr.io/tomusdrw/jammin-as-lan:1.2.3");
+  });
+
+  test("Accepts 'latest' as a literal version string", () => {
+    const result = resolveSdk("aslan@latest");
+    expect(result.image).toBe("ghcr.io/tomusdrw/jammin-as-lan:latest");
+  });
+
+  test("Accepts pre-release version with dot and hyphen", () => {
+    const result = resolveSdk("jade@0.1.0-rc.1");
+    expect(result.image).toBe("ghcr.io/fluffylabs/jammin-jade:0.1.0-rc.1");
+  });
+
+  test("Does not mutate the entry stored in SDK_CONFIGS", () => {
+    resolveSdk("aslan@9.9.9");
+    expect(SDK_CONFIGS["aslan@*"].image).toBe("ghcr.io/tomusdrw/jammin-as-lan:{version}");
+  });
+
+  test("Returned object does not carry the internal `deprecated` flag", () => {
+    const result = resolveSdk("aslan@0.1.0") as Record<string, unknown>;
+    expect("deprecated" in result).toBe(false);
+  });
+});
+
+describe("resolveSdk - deprecated exact match", () => {
+  let warnSpy: ReturnType<typeof mock>;
+  let originalWarn: typeof console.warn;
+
+  beforeEach(() => {
+    originalWarn = console.warn;
+    warnSpy = mock(() => {});
+    console.warn = warnSpy;
+    const mod = require("./sdk-configs.js") as { __resetDeprecationWarnings?: () => void };
+    mod.__resetDeprecationWarnings?.();
+  });
+
+  afterEach(() => {
+    console.warn = originalWarn;
+  });
+
+  test("Resolves 'aslan-0.0.6' to the dash entry's image", () => {
+    const result = resolveSdk("aslan-0.0.6");
+    expect(result.image).toBe("ghcr.io/tomusdrw/jammin-as-lan:0.0.6");
+    expect(result.build).toBe("npm run build");
+  });
+
+  test("Emits a console.warn mentioning the deprecation and a suggested replacement", () => {
+    resolveSdk("aslan-0.0.6");
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const msg = warnSpy.mock.calls[0]?.[0] as string;
+    expect(msg).toContain("aslan-0.0.6");
+    expect(msg).toContain("deprecated");
+    expect(msg).toContain("0.4.0");
+    expect(msg).toContain("aslan@0.0.6");
+  });
+
+  test("Deduplicates: same deprecated id warns at most once per process", () => {
+    resolveSdk("aslan-0.0.6");
+    resolveSdk("aslan-0.0.6");
+    resolveSdk("aslan-0.0.6");
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("Different deprecated ids each warn once", () => {
+    resolveSdk("aslan-0.0.6");
+    resolveSdk("jade-0.0.15-pre.1");
+    expect(warnSpy).toHaveBeenCalledTimes(2);
+  });
+
+  test("Does not warn for the jambrains-1cfc41c entry (not deprecated)", () => {
+    resolveSdk("jambrains-1cfc41c");
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  test("Returned object does not carry the internal `deprecated` flag", () => {
+    const result = resolveSdk("aslan-0.0.6") as Record<string, unknown>;
+    expect("deprecated" in result).toBe(false);
+  });
+});
+
+describe("resolveSdk - errors", () => {
+  test("Throws for a bare framework name with no version", () => {
+    expect(() => resolveSdk("aslan")).toThrow("Unknown SDK id: 'aslan'");
+  });
+
+  test("Throws for an unknown framework prefix", () => {
+    expect(() => resolveSdk("fake@1.0.0")).toThrow("Unknown SDK id: 'fake@1.0.0'");
+  });
+
+  test("Throws for a version containing whitespace", () => {
+    expect(() => resolveSdk("aslan@bad version")).toThrow("Unknown SDK id: 'aslan@bad version'");
+  });
+
+  test("Throws for a version containing a slash", () => {
+    expect(() => resolveSdk("aslan@1.0/0")).toThrow("Unknown SDK id: 'aslan@1.0/0'");
+  });
+
+  test("Throws for an empty version after '@'", () => {
+    expect(() => resolveSdk("aslan@")).toThrow("Unknown SDK id: 'aslan@'");
+  });
+
+  test("Throws with the original input for an empty string", () => {
+    expect(() => resolveSdk("")).toThrow("Unknown SDK id: ''");
+  });
+});
+
+describe("isKnownSdkId", () => {
+  test("Returns true for exact wildcard-substituted ids", () => {
+    expect(isKnownSdkId("aslan@0.1.0")).toBe(true);
+    expect(isKnownSdkId("aslan@latest")).toBe(true);
+    expect(isKnownSdkId("jade@0.0.15-pre.1")).toBe(true);
+  });
+
+  test("Returns true for exact deprecated dash keys", () => {
+    expect(isKnownSdkId("aslan-0.0.6")).toBe(true);
+    expect(isKnownSdkId("jam-sdk-0.1.26")).toBe(true);
+    expect(isKnownSdkId("jambrains-1cfc41c")).toBe(true);
+  });
+
+  test("Returns false for unknown ids", () => {
+    expect(isKnownSdkId("aslan")).toBe(false);
+    expect(isKnownSdkId("fake@1.0.0")).toBe(false);
+    expect(isKnownSdkId("aslan@bad version")).toBe(false);
+    expect(isKnownSdkId("aslan@")).toBe(false);
+    expect(isKnownSdkId("")).toBe(false);
+  });
+
+  test("Returns false for prototype property names", () => {
+    expect(isKnownSdkId("toString")).toBe(false);
+    expect(isKnownSdkId("constructor")).toBe(false);
+    expect(isKnownSdkId("hasOwnProperty")).toBe(false);
+  });
+});
+
+describe("ServiceConfig.sdk type accepts new wildcard form", () => {
   type Assert<T extends true> = T;
+  type _Versioned = Assert<"aslan@0.1.0" extends ServiceConfig["sdk"] ? true : false>;
+  type _AsLanVersioned = Assert<"as-lan@1.2.3" extends ServiceConfig["sdk"] ? true : false>;
+  type _DeprecatedPinned = Assert<"aslan-0.0.6" extends ServiceConfig["sdk"] ? true : false>;
+  type _Jambrains = Assert<"jambrains-1cfc41c" extends ServiceConfig["sdk"] ? true : false>;
 
-  // Compile-time assertions: these fail tsc if the union narrows.
-  type _AliasAccepted = Assert<"as-lan" extends ServiceConfig["sdk"] ? true : false>;
-  type _VersionedAliasAccepted = Assert<"as-lan-0.0.6" extends ServiceConfig["sdk"] ? true : false>;
-  type _CanonicalAccepted = Assert<"aslan-0.0.6" extends ServiceConfig["sdk"] ? true : false>;
-
-  test("Constructs a ServiceConfig literal with an alias key", () => {
-    const cfg: ServiceConfig = {
-      path: "./svc",
-      name: "svc",
-      sdk: "as-lan",
-    };
-    expect(cfg.sdk).toBe("as-lan");
+  test("Constructs a ServiceConfig literal with wildcard-versioned id", () => {
+    const cfg: ServiceConfig = { path: "./svc", name: "svc", sdk: "aslan@0.1.0" };
+    expect(cfg.sdk).toBe("aslan@0.1.0");
   });
 });

--- a/packages/jammin-sdk/config/sdk-configs.test.ts
+++ b/packages/jammin-sdk/config/sdk-configs.test.ts
@@ -141,6 +141,12 @@ describe("resolveSdk - errors", () => {
   test("Throws with the original input for an empty string", () => {
     expect(() => resolveSdk("")).toThrow("Unknown SDK id: ''");
   });
+
+  test("Throws for a literal wildcard key like 'aslan@*'", () => {
+    // The wildcard keys are an internal template, not a user-facing id.
+    expect(() => resolveSdk("aslan@*")).toThrow("Unknown SDK id: 'aslan@*'");
+    expect(() => resolveSdk("jamc3@*")).toThrow("Unknown SDK id: 'jamc3@*'");
+  });
 });
 
 describe("isKnownSdkId", () => {
@@ -162,6 +168,11 @@ describe("isKnownSdkId", () => {
     expect(isKnownSdkId("aslan@bad version")).toBe(false);
     expect(isKnownSdkId("aslan@")).toBe(false);
     expect(isKnownSdkId("")).toBe(false);
+  });
+
+  test("Returns false for literal wildcard keys like 'aslan@*'", () => {
+    expect(isKnownSdkId("aslan@*")).toBe(false);
+    expect(isKnownSdkId("jamc3@*")).toBe(false);
   });
 
   test("Returns false for prototype property names", () => {

--- a/packages/jammin-sdk/config/sdk-configs.ts
+++ b/packages/jammin-sdk/config/sdk-configs.ts
@@ -69,6 +69,10 @@ const VERSION_RE = /^[A-Za-z0-9._-]+$/;
 
 /** Predicate used by the validator to check if an SDK id is known. */
 export function isKnownSdkId(id: string): boolean {
+  // The literal `<name>@*` keys are an internal template mechanism, not user-facing ids.
+  if (id.endsWith("@*")) {
+    return false;
+  }
   if (Object.hasOwn(SDK_CONFIGS, id)) {
     return true;
   }
@@ -128,6 +132,12 @@ function warnOnceForDeprecated(id: string): void {
 export function resolveSdk(sdk: string | SdkConfig): SdkConfig {
   if (typeof sdk !== "string") {
     return sdk;
+  }
+
+  // The literal `<name>@*` keys are an internal template mechanism. Reject
+  // them so we never hand back an unresolved `{version}` image.
+  if (sdk.endsWith("@*")) {
+    throw new Error(`Unknown SDK id: '${sdk}'`);
   }
 
   if (Object.hasOwn(SDK_CONFIGS, sdk)) {

--- a/packages/jammin-sdk/config/sdk-configs.ts
+++ b/packages/jammin-sdk/config/sdk-configs.ts
@@ -24,7 +24,8 @@ export const SDK_CONFIGS = {
   // jambrains is pinned by sha256 digest, not by version tag. No wildcard
   // form. NOT deprecated.
   "jambrains-1cfc41c": {
-    image: "ghcr.io/jambrains/service-sdk:latest@sha256:1cfc41c23f5c348aaee5f5c70aaa24f10c26baf903de4b4f6774e2032820ba87",
+    image:
+      "ghcr.io/jambrains/service-sdk:latest@sha256:1cfc41c23f5c348aaee5f5c70aaa24f10c26baf903de4b4f6774e2032820ba87",
     build: "single-file main.c",
     test: "true",
   },

--- a/packages/jammin-sdk/config/sdk-configs.ts
+++ b/packages/jammin-sdk/config/sdk-configs.ts
@@ -3,11 +3,14 @@ import type { SdkConfig, SdkConfigEntry } from "./types/config.js";
 const aslanCommon = { build: "npm run build", test: "npm test" } as const;
 const jadeCommon = { build: "build", test: "test" } as const;
 
+// Shared so `aslan@*` and `as-lan@*` cannot drift out of sync.
+const aslanWildcard = { image: "ghcr.io/tomusdrw/jammin-as-lan:{version}", ...aslanCommon } as const;
+
 export const SDK_CONFIGS = {
   // Wildcard entries: `<name>@*`. The {version} placeholder in `image` is
   // substituted with the version segment from the user's `<name>@<version>` id.
-  "aslan@*": { image: "ghcr.io/tomusdrw/jammin-as-lan:{version}", ...aslanCommon },
-  "as-lan@*": { image: "ghcr.io/tomusdrw/jammin-as-lan:{version}", ...aslanCommon },
+  "aslan@*": aslanWildcard,
+  "as-lan@*": aslanWildcard,
   "jam-sdk@*": {
     image: "ghcr.io/fluffylabs/jammin-jam-sdk:{version}",
     build: "jam-pvm-build -m service",
@@ -144,7 +147,7 @@ export function resolveSdk(sdk: string | SdkConfig): SdkConfig {
       if (Object.hasOwn(SDK_CONFIGS, wildcardKey)) {
         const entry = SDK_CONFIGS[wildcardKey as keyof typeof SDK_CONFIGS] as SdkConfigEntry;
         const config = stripDeprecatedFlag(entry);
-        return { ...config, image: config.image.replace("{version}", version) };
+        return { ...config, image: config.image.replaceAll("{version}", version) };
       }
     }
   }

--- a/packages/jammin-sdk/config/sdk-configs.ts
+++ b/packages/jammin-sdk/config/sdk-configs.ts
@@ -1,70 +1,152 @@
-import type { SdkConfig } from "./types/config.js";
+import type { SdkConfig, SdkConfigEntry } from "./types/config.js";
+
+const aslanCommon = { build: "npm run build", test: "npm test" } as const;
+const jadeCommon = { build: "build", test: "test" } as const;
 
 export const SDK_CONFIGS = {
+  // Wildcard entries: `<name>@*`. The {version} placeholder in `image` is
+  // substituted with the version segment from the user's `<name>@<version>` id.
+  "aslan@*": { image: "ghcr.io/tomusdrw/jammin-as-lan:{version}", ...aslanCommon },
+  "as-lan@*": { image: "ghcr.io/tomusdrw/jammin-as-lan:{version}", ...aslanCommon },
+  "jam-sdk@*": {
+    image: "ghcr.io/fluffylabs/jammin-jam-sdk:{version}",
+    build: "jam-pvm-build -m service",
+    test: "cargo test",
+  },
+  "jade@*": { image: "ghcr.io/fluffylabs/jammin-jade:{version}", ...jadeCommon },
+  "ajanta@*": {
+    image: "ghcr.io/fluffylabs/jammin-ajanta:{version}",
+    build: "ajanta build main.py -o service.jam",
+    test: "true",
+  },
+  "jamc3@*": { image: "ghcr.io/dreverr/jamc3:{version}", build: "main.c3 -o service.jam", test: "--help" },
+
+  // jambrains is pinned by sha256 digest, not by version tag. No wildcard
+  // form. NOT deprecated.
+  "jambrains-1cfc41c": {
+    image: "ghcr.io/jambrains/service-sdk:latest@sha256:1cfc41c23f5c348aaee5f5c70aaa24f10c26baf903de4b4f6774e2032820ba87",
+    build: "single-file main.c",
+    test: "true",
+  },
+
+  // DEPRECATED: dash-style pinned keys are kept for back-compat in 0.3.x.
+  // Remove this entire block in 0.4.0. Downstream configs should use the
+  // `<name>@<version>` form (e.g. `aslan@0.0.6`).
   "jam-sdk-0.1.26": {
     image: "ghcr.io/fluffylabs/jammin-jam-sdk:0.1.26",
     build: "jam-pvm-build -m service",
     test: "cargo test",
+    deprecated: true,
   },
-  "jambrains-1cfc41c": {
-    image:
-      "ghcr.io/jambrains/service-sdk:latest@sha256:1cfc41c23f5c348aaee5f5c70aaa24f10c26baf903de4b4f6774e2032820ba87",
-    build: "single-file main.c",
-    test: "true",
-  },
-  "jade-0.0.15-pre.1": {
-    image: "ghcr.io/fluffylabs/jammin-jade:0.0.15-pre.1",
-    build: "build",
-    test: "test",
-  },
+  "jade-0.0.15-pre.1": { image: "ghcr.io/fluffylabs/jammin-jade:0.0.15-pre.1", ...jadeCommon, deprecated: true },
   "ajanta-0.1.0": {
     image: "ghcr.io/fluffylabs/jammin-ajanta:0.1.0",
     build: "ajanta build main.py -o service.jam",
     test: "true",
+    deprecated: true,
   },
   "jamc3-2.0.2": {
     image: "ghcr.io/dreverr/jamc3:2.0.2",
     build: "main.c3 -o service.jam",
     test: "--help",
+    deprecated: true,
   },
-  "aslan-0.0.6": {
-    image: "ghcr.io/tomusdrw/jammin-as-lan:0.0.6",
-    build: "npm run build",
-    test: "npm test",
-  },
-} as const satisfies Record<string, SdkConfig>;
+  "aslan-0.0.6": { image: "ghcr.io/tomusdrw/jammin-as-lan:0.0.6", ...aslanCommon, deprecated: true },
+} as const satisfies Record<string, SdkConfigEntry>;
 
-export const SDK_ALIASES = {
-  "as-lan": "aslan-0.0.6",
-  "as-lan-0.0.6": "aslan-0.0.6",
-} as const satisfies Record<string, keyof typeof SDK_CONFIGS>;
-
-/**
- * Resolve a string SDK identifier (canonical key or alias) to a canonical
- * SDK_CONFIGS key. Returns undefined for unknown identifiers.
- */
-export function resolveSdkId(id: string): keyof typeof SDK_CONFIGS | undefined {
-  if (Object.hasOwn(SDK_CONFIGS, id)) {
-    return id as keyof typeof SDK_CONFIGS;
+// Module-load invariant: every wildcard entry must contain a {version} placeholder.
+for (const [key, entry] of Object.entries(SDK_CONFIGS)) {
+  if (key.endsWith("@*") && !entry.image.includes("{version}")) {
+    throw new Error(`SDK_CONFIGS entry '${key}' must include '{version}' in image`);
   }
-  if (Object.hasOwn(SDK_ALIASES, id)) {
-    return SDK_ALIASES[id as keyof typeof SDK_ALIASES];
+}
+
+const VERSION_RE = /^[A-Za-z0-9._-]+$/;
+
+/** Predicate used by the validator to check if an SDK id is known. */
+export function isKnownSdkId(id: string): boolean {
+  if (Object.hasOwn(SDK_CONFIGS, id)) {
+    return true;
+  }
+  const at = id.indexOf("@");
+  if (at < 0) {
+    return false;
+  }
+  const name = id.slice(0, at);
+  const version = id.slice(at + 1);
+  if (!VERSION_RE.test(version)) {
+    return false;
+  }
+  return Object.hasOwn(SDK_CONFIGS, `${name}@*`);
+}
+
+const warned = new Set<string>();
+
+/** Test-only: reset the dedup set used by the deprecation warning. */
+export function __resetDeprecationWarnings(): void {
+  warned.clear();
+}
+
+function stripDeprecatedFlag(entry: SdkConfigEntry): SdkConfig {
+  const { deprecated: _deprecated, ...config } = entry;
+  return config;
+}
+
+function suggestReplacement(deprecatedKey: string): string | undefined {
+  const match = deprecatedKey.match(/^(.+?)-(\d.*)$/);
+  if (!match) {
+    return undefined;
+  }
+  const [, name, version] = match;
+  if (Object.hasOwn(SDK_CONFIGS, `${name}@*`)) {
+    return `${name}@${version}`;
   }
   return undefined;
 }
 
+function warnOnceForDeprecated(id: string): void {
+  if (warned.has(id)) {
+    return;
+  }
+  warned.add(id);
+  const suggestion = suggestReplacement(id);
+  const tail = suggestion ? ` Use '${suggestion}' instead.` : "";
+  console.warn(`[jammin] SDK id '${id}' is deprecated and will be removed in 0.4.0.${tail}`);
+}
+
 /**
- * Resolve a service's `sdk` field to a concrete SdkConfig. Accepts canonical
- * keys, alias keys, or an inline SdkConfig object. Throws for unknown string
- * identifiers.
+ * Resolve a service's `sdk` field to a concrete SdkConfig. Accepts:
+ * - a canonical wildcard-versioned id (`<name>@<version>`),
+ * - a deprecated pinned id (e.g. `aslan-0.0.6`),
+ * - or an inline SdkConfig object.
+ * Throws for unknown string ids.
  */
 export function resolveSdk(sdk: string | SdkConfig): SdkConfig {
   if (typeof sdk !== "string") {
     return sdk;
   }
-  const canonicalId = resolveSdkId(sdk);
-  if (!canonicalId) {
-    throw new Error(`Unknown SDK id: '${sdk}'`);
+
+  if (Object.hasOwn(SDK_CONFIGS, sdk)) {
+    const entry = SDK_CONFIGS[sdk as keyof typeof SDK_CONFIGS] as SdkConfigEntry;
+    if (entry.deprecated) {
+      warnOnceForDeprecated(sdk);
+    }
+    return stripDeprecatedFlag(entry);
   }
-  return SDK_CONFIGS[canonicalId];
+
+  const at = sdk.indexOf("@");
+  if (at >= 0) {
+    const name = sdk.slice(0, at);
+    const version = sdk.slice(at + 1);
+    if (VERSION_RE.test(version)) {
+      const wildcardKey = `${name}@*`;
+      if (Object.hasOwn(SDK_CONFIGS, wildcardKey)) {
+        const entry = SDK_CONFIGS[wildcardKey as keyof typeof SDK_CONFIGS] as SdkConfigEntry;
+        const config = stripDeprecatedFlag(entry);
+        return { ...config, image: config.image.replace("{version}", version) };
+      }
+    }
+  }
+
+  throw new Error(`Unknown SDK id: '${sdk}'`);
 }

--- a/packages/jammin-sdk/config/types/config.ts
+++ b/packages/jammin-sdk/config/types/config.ts
@@ -1,6 +1,6 @@
 // Core configuration types matching YAML schema
 
-import type { SDK_ALIASES, SDK_CONFIGS } from "../sdk-configs.js";
+import type { SDK_CONFIGS } from "../sdk-configs.js";
 
 // jammin.build.yml types
 
@@ -9,13 +9,18 @@ export interface JamminBuildConfig {
   deployment?: DeploymentConfig;
 }
 
+type WildcardKey = Extract<keyof typeof SDK_CONFIGS, `${string}@*`>;
+type WildcardName = WildcardKey extends `${infer N}@*` ? N : never;
+type PinnedKey = Exclude<keyof typeof SDK_CONFIGS, WildcardKey>;
+type VersionedKey = `${WildcardName}@${string}`;
+
 export interface ServiceConfig {
   /** Path to service directory */
   path: string;
   /** Service identifier */
   name: string;
-  /** SDK name (built-in) or custom sdk */
-  sdk: keyof typeof SDK_CONFIGS | keyof typeof SDK_ALIASES | SdkConfig;
+  /** SDK id: `<name>@<version>`, a deprecated pinned key, or an inline config. */
+  sdk: PinnedKey | VersionedKey | SdkConfig;
 }
 
 export interface SdkConfig {
@@ -25,6 +30,11 @@ export interface SdkConfig {
   build: string;
   /** Test command */
   test: string;
+}
+
+/** Internal: `SdkConfig` plus an optional `deprecated` flag used by the resolver. */
+export interface SdkConfigEntry extends SdkConfig {
+  deprecated?: boolean;
 }
 
 export interface DeploymentConfig {


### PR DESCRIPTION
## Summary

- Replace per-version `SDK_CONFIGS` entries with `<name>@*` wildcard templates that substitute the version into the docker image tag. Downstream `jammin.build.yml` files now pin `aslan@0.0.6` instead of requiring a new entry per release.
- Dash-style pinned keys (`aslan-0.0.6`, `jam-sdk-0.1.26`, `jade-0.0.15-pre.1`, `ajanta-0.1.0`, `jamc3-1.1.2`) still resolve in 0.3.x but emit a one-time deprecation warning. To be removed in 0.4.0 — tracked in #125.
- Removes `SDK_ALIASES` (unused) and the `resolveSdkId` helper (folded into `resolveSdk` + new `isKnownSdkId` predicate).

## Design

Spec: `docs/superpowers/specs/2026-05-15-wildcard-sdk-versions-design.md` (local; `docs/superpowers/` is gitignored).

- Wildcard entry: `"<name>@*": { image: "...:{version}", build, test }`. A module-load invariant rejects entries that forget the `{version}` placeholder.
- Resolution: exact match first (covers deprecated keys + the sha-pinned `jambrains-1cfc41c`), else split on `@`, validate version against `^[A-Za-z0-9._-]+$`, look up `<name>@*`, substitute.
- Validator: `z.string()` refined by `isKnownSdkId` (replaces the enum-of-keys). Custom error lists supported wildcards + deprecated pinned ids.
- Types: `ServiceConfig.sdk` is a template-literal union derived from `SDK_CONFIGS` keys (`PinnedKey | \`${WildcardName}@${string}\` | SdkConfig`), preserving autocomplete for the framework prefix.

## Test plan

- [ ] `bun run qa && bun run build && bun test` — already passing locally (177 pass, 1 skip).
- [ ] Smoke test: a downstream `jammin.build.yml` with `sdk: aslan@0.0.6` resolves and invokes `ghcr.io/tomusdrw/jammin-as-lan:0.0.6` (verified locally).
- [ ] Smoke test: a downstream config still using `sdk: aslan-0.0.6` resolves and emits `[jammin] SDK id 'aslan-0.0.6' is deprecated and will be removed in 0.4.0. Use 'aslan@0.0.6' instead.` (verified locally).

## Follow-up

- #125 — Remove deprecated dash-style SDK keys in 0.4.0