### PR TITLE
feat(sdk-configs): sha256 digest pinning for wildcard SDKs

### DIFF
--- a/docs/src/service-examples.md
+++ b/docs/src/service-examples.md
@@ -112,12 +112,14 @@ Use the `<name>@<version>` form:
 - `as-lan@0.0.6` (separate wildcard entry pointing at the same image)
 - `aslan@latest` — pulls the `latest` tag (not reproducible; pin a concrete version for shared projects)
 - `aslan@0.1.0-rc.1` — pre-release tags work, the version segment is passed through verbatim
+- `aslan@sha256:<64-hex-digest>` — sha-pinned form, available on every wildcard SDK. Resolves to `<repo>@sha256:<digest>` (no tag). Use this for images that only publish moving tags (e.g. `jambrains` publishes only `:latest`).
 
-The version segment must match `[A-Za-z0-9._-]+` and is substituted into the
-docker image tag at resolve time.
+The version segment must match either `[A-Za-z0-9._-]+` (a docker tag) or
+`sha256:` followed by exactly 64 lowercase hex chars (a digest). Partial
+digests are rejected at config-load time.
 
 > **Deprecated**: the pinned dash-style keys (`aslan-0.0.6`, `jam-sdk-0.1.26`,
-> `jade-0.0.15-pre.1`, `ajanta-0.1.0`, `jamc3-1.1.2`) still resolve in 0.3.x but
-> emit a one-time `console.warn` and will be removed in 0.4.0. Migrate to the
-> `<name>@<version>` form. The `jambrains-1cfc41c` entry is not deprecated — it
-> is pinned by sha256 digest, not by a version tag.
+> `jade-0.0.15-pre.1`, `ajanta-0.1.0`, `jamc3-1.1.2`, `jambrains-1cfc41c`) still
+> resolve in 0.3.x but emit a one-time `console.warn` and will be removed in
+> 0.4.0. Migrate to the `<name>@<version>` form. The `jambrains-1cfc41c` entry
+> migrates to `jambrains@sha256:1cfc41c23f5c348aaee5f5c70aaa24f10c26baf903de4b4f6774e2032820ba87`.

--- a/packages/jammin-sdk/config/sdk-configs.test.ts
+++ b/packages/jammin-sdk/config/sdk-configs.test.ts
@@ -50,6 +50,30 @@ describe("resolveSdk - wildcard substitution", () => {
     expect(result.image).toBe("ghcr.io/fluffylabs/jammin-jade:0.1.0-rc.1");
   });
 
+  test("Rewrites `:{version}` to `@{version}` for sha256 digest pins", () => {
+    const digest = "1cfc41c23f5c348aaee5f5c70aaa24f10c26baf903de4b4f6774e2032820ba87";
+    const result = resolveSdk(`aslan@sha256:${digest}`);
+    expect(result.image).toBe(`ghcr.io/tomusdrw/jammin-as-lan@sha256:${digest}`);
+  });
+
+  test("Resolves the jambrains wildcard with a sha256 digest", () => {
+    const digest = "1cfc41c23f5c348aaee5f5c70aaa24f10c26baf903de4b4f6774e2032820ba87";
+    const result = resolveSdk(`jambrains@sha256:${digest}`);
+    expect(result.image).toBe(`ghcr.io/jambrains/service-sdk@sha256:${digest}`);
+    expect(result.build).toBe("single-file main.c");
+  });
+
+  test("Sha pinning works for every wildcard SDK", () => {
+    const digest = `sha256:${"a".repeat(64)}`;
+    for (const key of Object.keys(SDK_CONFIGS).filter((k) => k.endsWith("@*"))) {
+      const name = key.slice(0, -2);
+      const result = resolveSdk(`${name}@${digest}`);
+      expect(result.image).toContain(`@${digest}`);
+      // Tag separator should be gone since the digest replaced it
+      expect(result.image).not.toContain(`:${digest}`);
+    }
+  });
+
   test("Does not mutate the entry stored in SDK_CONFIGS", () => {
     resolveSdk("aslan@9.9.9");
     expect(SDK_CONFIGS["aslan@*"].image).toBe("ghcr.io/tomusdrw/jammin-as-lan:{version}");
@@ -106,9 +130,18 @@ describe("resolveSdk - deprecated exact match", () => {
     expect(warnSpy).toHaveBeenCalledTimes(2);
   });
 
-  test("Does not warn for the jambrains-1cfc41c entry (not deprecated)", () => {
+  test("Warns for the jambrains-1cfc41c entry and suggests the full-digest replacement", () => {
     resolveSdk("jambrains-1cfc41c");
-    expect(warnSpy).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const msg = warnSpy.mock.calls[0]?.[0] as string;
+    expect(msg).toContain("jambrains-1cfc41c");
+    expect(msg).toContain("deprecated");
+    expect(msg).toContain("0.4.0");
+    // The auto-suggestion (`jambrains@1cfc41c`) would be invalid under the
+    // strict sha256 version validator; the entry's explicit `replacement`
+    // points at the full-digest form instead.
+    expect(msg).toContain("jambrains@sha256:1cfc41c23f5c348aaee5f5c70aaa24f10c26baf903de4b4f6774e2032820ba87");
+    expect(msg).not.toMatch(/jambrains@1cfc41c\b/);
   });
 
   test("Returned object does not carry the internal `deprecated` flag", () => {
@@ -160,6 +193,20 @@ describe("isKnownSdkId", () => {
     expect(isKnownSdkId("aslan-0.0.6")).toBe(true);
     expect(isKnownSdkId("jam-sdk-0.1.26")).toBe(true);
     expect(isKnownSdkId("jambrains-1cfc41c")).toBe(true);
+  });
+
+  test("Returns true for a full sha256 digest version on any wildcard", () => {
+    const digest = "1cfc41c23f5c348aaee5f5c70aaa24f10c26baf903de4b4f6774e2032820ba87";
+    expect(isKnownSdkId(`aslan@sha256:${digest}`)).toBe(true);
+    expect(isKnownSdkId(`jambrains@sha256:${digest}`)).toBe(true);
+  });
+
+  test("Returns false for malformed sha256 versions", () => {
+    expect(isKnownSdkId("aslan@sha256:abc")).toBe(false);
+    expect(isKnownSdkId("aslan@sha256:")).toBe(false);
+    expect(isKnownSdkId("aslan@sha512:0123456789abcdef".padEnd(78, "0"))).toBe(false);
+    // Uppercase hex is not accepted - canonical digests are lowercase
+    expect(isKnownSdkId(`aslan@sha256:${"A".repeat(64)}`)).toBe(false);
   });
 
   test("Returns false for unknown ids", () => {

--- a/packages/jammin-sdk/config/sdk-configs.ts
+++ b/packages/jammin-sdk/config/sdk-configs.ts
@@ -23,12 +23,11 @@ export const SDK_CONFIGS = {
     test: "true",
   },
   "jamc3@*": { image: "ghcr.io/dreverr/jamc3:{version}", build: "main.c3 -o service.jam", test: "--help" },
-
-  // jambrains is pinned by sha256 digest, not by version tag. No wildcard
-  // form. NOT deprecated.
-  "jambrains-1cfc41c": {
-    image:
-      "ghcr.io/jambrains/service-sdk:latest@sha256:1cfc41c23f5c348aaee5f5c70aaa24f10c26baf903de4b4f6774e2032820ba87",
+  // The jambrains image only publishes a `:latest` tag, so the recommended
+  // form here is the sha256 digest: `jambrains@sha256:<64-hex-digest>`. Tag
+  // form (`jambrains@latest`) works too but is not reproducible.
+  "jambrains@*": {
+    image: "ghcr.io/jambrains/service-sdk:{version}",
     build: "single-file main.c",
     test: "true",
   },
@@ -56,6 +55,17 @@ export const SDK_CONFIGS = {
     deprecated: true,
   },
   "aslan-0.0.6": { image: "ghcr.io/tomusdrw/jammin-as-lan:0.0.6", ...aslanCommon, deprecated: true },
+  // The truncated-sha key cannot be mechanically converted to `jambrains@<short>`
+  // because the strict version validator requires a full 64-hex sha256 digest,
+  // so an explicit `replacement` is supplied for the deprecation warning.
+  "jambrains-1cfc41c": {
+    image:
+      "ghcr.io/jambrains/service-sdk:latest@sha256:1cfc41c23f5c348aaee5f5c70aaa24f10c26baf903de4b4f6774e2032820ba87",
+    build: "single-file main.c",
+    test: "true",
+    deprecated: true,
+    replacement: "jambrains@sha256:1cfc41c23f5c348aaee5f5c70aaa24f10c26baf903de4b4f6774e2032820ba87",
+  },
 } as const satisfies Record<string, SdkConfigEntry>;
 
 // Module-load invariant: every wildcard entry must contain a {version} placeholder.
@@ -65,7 +75,11 @@ for (const [key, entry] of Object.entries(SDK_CONFIGS)) {
   }
 }
 
-const VERSION_RE = /^[A-Za-z0-9._-]+$/;
+// Accepts either a docker tag (alphanumerics + `._-`) or a full sha256 digest
+// (`sha256:` followed by exactly 64 lowercase hex chars). Partial digests are
+// rejected here so config-load fails fast instead of docker rejecting later.
+const VERSION_RE = /^(?:[A-Za-z0-9._-]+|sha256:[a-f0-9]{64})$/;
+const SHA256_PREFIX = "sha256:";
 
 /** Predicate used by the validator to check if an SDK id is known. */
 export function isKnownSdkId(id: string): boolean {
@@ -95,12 +109,15 @@ export function __resetDeprecationWarnings(): void {
   warned.clear();
 }
 
-function stripDeprecatedFlag(entry: SdkConfigEntry): SdkConfig {
-  const { deprecated: _deprecated, ...config } = entry;
+function toPublicConfig(entry: SdkConfigEntry): SdkConfig {
+  const { deprecated: _deprecated, replacement: _replacement, ...config } = entry;
   return config;
 }
 
-function suggestReplacement(deprecatedKey: string): string | undefined {
+function suggestReplacement(deprecatedKey: string, entry: SdkConfigEntry): string | undefined {
+  if (entry.replacement !== undefined) {
+    return entry.replacement;
+  }
   const match = deprecatedKey.match(/^(.+?)-(\d.*)$/);
   if (!match) {
     return undefined;
@@ -112,12 +129,12 @@ function suggestReplacement(deprecatedKey: string): string | undefined {
   return undefined;
 }
 
-function warnOnceForDeprecated(id: string): void {
+function warnOnceForDeprecated(id: string, entry: SdkConfigEntry): void {
   if (warned.has(id)) {
     return;
   }
   warned.add(id);
-  const suggestion = suggestReplacement(id);
+  const suggestion = suggestReplacement(id, entry);
   const tail = suggestion ? ` Use '${suggestion}' instead.` : "";
   console.warn(`[jammin] SDK id '${id}' is deprecated and will be removed in 0.4.0.${tail}`);
 }
@@ -143,9 +160,9 @@ export function resolveSdk(sdk: string | SdkConfig): SdkConfig {
   if (Object.hasOwn(SDK_CONFIGS, sdk)) {
     const entry = SDK_CONFIGS[sdk as keyof typeof SDK_CONFIGS] as SdkConfigEntry;
     if (entry.deprecated) {
-      warnOnceForDeprecated(sdk);
+      warnOnceForDeprecated(sdk, entry);
     }
-    return stripDeprecatedFlag(entry);
+    return toPublicConfig(entry);
   }
 
   const at = sdk.indexOf("@");
@@ -156,8 +173,15 @@ export function resolveSdk(sdk: string | SdkConfig): SdkConfig {
       const wildcardKey = `${name}@*`;
       if (Object.hasOwn(SDK_CONFIGS, wildcardKey)) {
         const entry = SDK_CONFIGS[wildcardKey as keyof typeof SDK_CONFIGS] as SdkConfigEntry;
-        const config = stripDeprecatedFlag(entry);
-        return { ...config, image: config.image.replaceAll("{version}", version) };
+        const config = toPublicConfig(entry);
+        // Wildcard templates carry `:{version}` for tags. When the user passes
+        // a digest, rewrite that separator to `@` so the resolved reference is
+        // `repo@sha256:...` (digest form) rather than `repo:sha256:...` (which
+        // docker would reject).
+        const template = version.startsWith(SHA256_PREFIX)
+          ? config.image.replace(":{version}", "@{version}")
+          : config.image;
+        return { ...config, image: template.replaceAll("{version}", version) };
       }
     }
   }

--- a/packages/jammin-sdk/config/types/config.ts
+++ b/packages/jammin-sdk/config/types/config.ts
@@ -32,9 +32,15 @@ export interface SdkConfig {
   test: string;
 }
 
-/** Internal: `SdkConfig` plus an optional `deprecated` flag used by the resolver. */
+/** Internal: `SdkConfig` plus optional flags consumed by the resolver. */
 export interface SdkConfigEntry extends SdkConfig {
   deprecated?: boolean;
+  /**
+   * Explicit replacement id used in the deprecation warning. Overrides the
+   * auto-suggested `<name>@<version>` form when the dash-style key cannot be
+   * mechanically converted (e.g. truncated sha digests).
+   */
+  replacement?: string;
 }
 
 export interface DeploymentConfig {


### PR DESCRIPTION
## Summary

Generalise the `<name>@<version>` wildcard resolution introduced in 0.3.0 to also accept a full sha256 digest as the version segment. When the version starts with `sha256:` the resolver rewrites the `:{version}` separator in the image template to `@{version}`, yielding a digest-pinned reference. Works for every wildcard SDK — including the new `jambrains@*` — not just one special case.

## Why

`jammin-create/jammin-create-jambrains` and the corresponding `services/example-jambrains/` in `jammin-create-undecided` cannot move to the canonical `<name>@<version>` form today, because the only published tag for `ghcr.io/jambrains/service-sdk` is `:latest` — there is no immutable tag to pin against, so the only reproducible identifier is the digest. The previous `jambrains-1cfc41c` entry handled this with a special-case exact-match key carrying a single hard-coded image; adding a new digest would have required another such entry. With this PR, downstream configs can simply write `jambrains@sha256:<digest>` and the wildcard handles it the same way `aslan@0.0.6` is handled.

This also unlocks digest pinning for the other SDKs whenever someone needs it (e.g. for stronger supply-chain guarantees than tag-based pinning).

## Design

- **Syntax.** `<name>@sha256:<64-hex-digest>`, following the docker convention. Bare hex without the `sha256:` prefix is intentionally rejected — no auto-detection.
- **Image template** stays as `repo:{version}`. The resolver rewrites the `:{version}` separator to `@{version}` when the version starts with `sha256:`, so `aslan@sha256:abc…` → `ghcr.io/tomusdrw/jammin-as-lan@sha256:abc…` (no tag).
- **Validator.** `VERSION_RE` widened to accept either `[A-Za-z0-9._-]+` (tags) or `sha256:[a-f0-9]{64}` (digest). Partial digests (`sha256:abc`) and other hash algos are rejected at config-load time, not at docker-pull time.
- **`SdkConfigEntry`** gained an optional `replacement` field. The deprecation suggestion for `jambrains-1cfc41c` would otherwise auto-resolve to `jambrains@1cfc41c`, which the strict validator rightly rejects. The explicit `replacement` points at `jambrains@sha256:1cfc41c23f5c348aaee5f5c70aaa24f10c26baf903de4b4f6774e2032820ba87` (the full digest the existing image was already pinned to). General-purpose hook for any future entry whose auto-suggestion would be wrong.
- **`jambrains-1cfc41c` is now deprecated** alongside the other dash-style keys, removed in 0.4.0 (#125).

## Test plan

- [x] `bun run qa` clean (Biome).
- [x] `bun test` — 184 pass, 1 skip, 0 fail.
- [x] New tests cover: digest resolution across every wildcard, malformed sha256 inputs (too short / wrong algo / uppercase hex), jambrains digest substitution, and the deprecation warning's explicit replacement.

## Follow-ups

- Once a release containing this lands, downstream `jammin-create/jammin-create-jambrains` and `jammin-create/jammin-create-undecided` can drop `jambrains-1cfc41c` for `jambrains@sha256:1cfc41c…` (separate PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)