### PR TITLE
fix(cli): force --platform=linux/amd64 on docker runs; refactor + per-SDK override

### DIFF
--- a/bin/cli/src/commands/build-command.test.ts
+++ b/bin/cli/src/commands/build-command.test.ts
@@ -130,6 +130,30 @@ describe("build-command", () => {
       expect(dockerCommand).toContain(`${resolve("/test/project", "./custom")}:/app`);
     });
 
+    test("should honor SdkConfig.platform when set", async () => {
+      const service: ServiceConfig = {
+        name: "arm-service",
+        path: "./custom",
+        sdk: {
+          image: "multi-arch-image:latest",
+          build: "build",
+          test: "test",
+          platform: "linux/arm64",
+        },
+      };
+
+      await callDockerBuild(service, "/test/project");
+
+      const spawnCall = mockSpawn.mock.calls[0];
+      if (!spawnCall) {
+        throw new Error("spawnCall is undefined");
+      }
+      const dockerCommand = spawnCall[0][2] as string;
+
+      expect(dockerCommand).toContain("--platform=linux/arm64");
+      expect(dockerCommand).not.toContain("--platform=linux/amd64");
+    });
+
     test("should handle build failure with non-zero exit code", async () => {
       const mockFailedSpawn = mock(() => {
         return {

--- a/bin/cli/src/commands/build-command.test.ts
+++ b/bin/cli/src/commands/build-command.test.ts
@@ -51,7 +51,11 @@ describe("build-command", () => {
       expect(spawnCall[0]).toEqual(["sh", "-c", expect.stringContaining("docker")]);
 
       const dockerCommand = spawnCall[0][2] as string;
-      expect(dockerCommand).toContain("docker run --rm -v");
+      expect(dockerCommand).toContain("docker run");
+      expect(dockerCommand).toContain("--rm");
+      // The jambrains image only publishes linux/amd64 manifests; without this
+      // flag the implicit pull fails on Apple Silicon hosts. See issue #111.
+      expect(dockerCommand).toContain("--platform=linux/amd64");
       expect(dockerCommand).toContain(`${resolve("/test/project", "./services/test")}:/app`);
       expect(dockerCommand).toContain(SDK_CONFIGS["jambrains-1cfc41c"].image);
       expect(dockerCommand).toContain(SDK_CONFIGS["jambrains-1cfc41c"].build);

--- a/bin/cli/src/commands/build-command.ts
+++ b/bin/cli/src/commands/build-command.ts
@@ -28,7 +28,17 @@ export async function callDockerBuild(service: ServiceConfig, projectRoot: strin
   const sdk = resolveSdk(service.sdk);
   const servicePath = resolve(projectRoot, service.path);
 
-  const dockerArgs = ["run", "--rm", "-v", `${servicePath}:/app`, sdk.image, ...sdk.build.split(" ")];
+  // SDK images currently ship only linux/amd64; force the platform so that the
+  // implicit `docker pull` works on Apple Silicon and other arm64 hosts (#111).
+  const dockerArgs = [
+    "run",
+    "--rm",
+    "--platform=linux/amd64",
+    "-v",
+    `${servicePath}:/app`,
+    sdk.image,
+    ...sdk.build.split(" "),
+  ];
   const dockerCommand = `docker ${dockerArgs.join(" ")}`;
 
   const proc = Bun.spawn(["sh", "-c", `${dockerCommand} 2>&1`], {

--- a/bin/cli/src/commands/build-command.ts
+++ b/bin/cli/src/commands/build-command.ts
@@ -8,52 +8,17 @@ import {
   getJamFiles,
   getServiceConfigs,
   loadServices,
-  resolveSdk,
 } from "@fluffylabs/jammin-sdk";
 import { Command } from "commander";
+import { runSdkDocker } from "../utils/run-sdk-docker.ts";
+
+export { DockerError } from "../utils/run-sdk-docker.ts";
 
 /**
  * Build a single service using Docker
  */
-export class DockerError extends Error {
-  constructor(
-    message: string,
-    public output: string,
-  ) {
-    super(message);
-  }
-}
-
 export async function callDockerBuild(service: ServiceConfig, projectRoot: string): Promise<string> {
-  const sdk = resolveSdk(service.sdk);
-  const servicePath = resolve(projectRoot, service.path);
-
-  // SDK images currently ship only linux/amd64; force the platform so that the
-  // implicit `docker pull` works on Apple Silicon and other arm64 hosts (#111).
-  const dockerArgs = [
-    "run",
-    "--rm",
-    "--platform=linux/amd64",
-    "-v",
-    `${servicePath}:/app`,
-    sdk.image,
-    ...sdk.build.split(" "),
-  ];
-  const dockerCommand = `docker ${dockerArgs.join(" ")}`;
-
-  const proc = Bun.spawn(["sh", "-c", `${dockerCommand} 2>&1`], {
-    stdout: "pipe",
-    stderr: "pipe",
-    cwd: projectRoot,
-  });
-
-  const [combinedOutput, exitCode] = await Promise.all([new Response(proc.stdout).text(), proc.exited]);
-
-  if (exitCode !== 0) {
-    throw new DockerError(`Build failed for service '${service.name}' with exit code ${exitCode}`, combinedOutput);
-  }
-
-  return combinedOutput;
+  return runSdkDocker(service, projectRoot, "build");
 }
 
 export async function buildService(service: ServiceConfig, projectRoot: string): Promise<string> {

--- a/bin/cli/src/commands/start-command.test.ts
+++ b/bin/cli/src/commands/start-command.test.ts
@@ -192,6 +192,7 @@ describe("start-command", () => {
         "docker",
         "run",
         "--rm",
+        "--platform=linux/amd64",
         "-v",
         "/tmp/filtered-genesis.json:/app/genesis.json:ro",
         "-v",

--- a/bin/cli/src/commands/start-command.ts
+++ b/bin/cli/src/commands/start-command.ts
@@ -58,6 +58,9 @@ export async function startContainer(filteredGenesisPath: string): Promise<void>
   const dockerArgs: string[] = [
     "run",
     "--rm",
+    // Match `pullImage` above. Defense in depth: if the local image cache
+    // happens to hold a different-arch entry, force the amd64 one.
+    "--platform=linux/amd64",
     "-v",
     `${filteredGenesisPath}:/app/genesis.json:ro`,
     "-v",

--- a/bin/cli/src/commands/test-command.test.ts
+++ b/bin/cli/src/commands/test-command.test.ts
@@ -51,7 +51,11 @@ describe("test-command", () => {
       expect(spawnCall[0]).toEqual(["sh", "-c", expect.stringContaining("docker")]);
 
       const dockerCommand = spawnCall[0][2] as string;
-      expect(dockerCommand).toContain("docker run --rm -v");
+      expect(dockerCommand).toContain("docker run");
+      expect(dockerCommand).toContain("--rm");
+      // The jambrains image only publishes linux/amd64 manifests; without this
+      // flag the implicit pull fails on Apple Silicon hosts. See issue #111.
+      expect(dockerCommand).toContain("--platform=linux/amd64");
       expect(dockerCommand).toContain(`${resolve("/test/project", "./services/test")}:/app`);
       expect(dockerCommand).toContain(SDK_CONFIGS["jambrains-1cfc41c"].image);
       expect(dockerCommand).toContain(SDK_CONFIGS["jambrains-1cfc41c"].test);

--- a/bin/cli/src/commands/test-command.ts
+++ b/bin/cli/src/commands/test-command.ts
@@ -1,52 +1,18 @@
 import { mkdir } from "node:fs/promises";
-import { join, relative, resolve } from "node:path";
+import { join, relative } from "node:path";
 import * as p from "@clack/prompts";
 import type { ServiceConfig } from "@fluffylabs/jammin-sdk";
-import { getServiceConfigs, resolveSdk } from "@fluffylabs/jammin-sdk";
+import { getServiceConfigs } from "@fluffylabs/jammin-sdk";
 import { Command } from "commander";
+import { DockerError, runSdkDocker } from "../utils/run-sdk-docker.ts";
 
-export class DockerError extends Error {
-  constructor(
-    message: string,
-    public output: string,
-  ) {
-    super(message);
-  }
-}
+export { DockerError } from "../utils/run-sdk-docker.ts";
 
 /**
  * Test a single service using Docker
  */
 export async function testService(service: ServiceConfig, projectRoot: string): Promise<string> {
-  const sdk = resolveSdk(service.sdk);
-  const servicePath = resolve(projectRoot, service.path);
-
-  // SDK images currently ship only linux/amd64; force the platform so that the
-  // implicit `docker pull` works on Apple Silicon and other arm64 hosts (#111).
-  const dockerArgs = [
-    "run",
-    "--rm",
-    "--platform=linux/amd64",
-    "-v",
-    `${servicePath}:/app`,
-    sdk.image,
-    ...sdk.test.split(" "),
-  ];
-  const dockerCommand = `docker ${dockerArgs.join(" ")}`;
-
-  const proc = Bun.spawn(["sh", "-c", `${dockerCommand} 2>&1`], {
-    stdout: "pipe",
-    stderr: "pipe",
-    cwd: projectRoot,
-  });
-
-  const [combinedOutput, exitCode] = await Promise.all([new Response(proc.stdout).text(), proc.exited]);
-
-  if (exitCode !== 0) {
-    throw new DockerError(`Tests failed for service '${service.name}' with exit code ${exitCode}`, combinedOutput);
-  }
-
-  return combinedOutput;
+  return runSdkDocker(service, projectRoot, "test");
 }
 
 /**

--- a/bin/cli/src/commands/test-command.ts
+++ b/bin/cli/src/commands/test-command.ts
@@ -21,7 +21,17 @@ export async function testService(service: ServiceConfig, projectRoot: string): 
   const sdk = resolveSdk(service.sdk);
   const servicePath = resolve(projectRoot, service.path);
 
-  const dockerArgs = ["run", "--rm", "-v", `${servicePath}:/app`, sdk.image, ...sdk.test.split(" ")];
+  // SDK images currently ship only linux/amd64; force the platform so that the
+  // implicit `docker pull` works on Apple Silicon and other arm64 hosts (#111).
+  const dockerArgs = [
+    "run",
+    "--rm",
+    "--platform=linux/amd64",
+    "-v",
+    `${servicePath}:/app`,
+    sdk.image,
+    ...sdk.test.split(" "),
+  ];
   const dockerCommand = `docker ${dockerArgs.join(" ")}`;
 
   const proc = Bun.spawn(["sh", "-c", `${dockerCommand} 2>&1`], {

--- a/bin/cli/src/utils/run-sdk-docker.ts
+++ b/bin/cli/src/utils/run-sdk-docker.ts
@@ -1,0 +1,54 @@
+import { resolve } from "node:path";
+import type { ServiceConfig } from "@fluffylabs/jammin-sdk";
+import { resolveSdk } from "@fluffylabs/jammin-sdk";
+
+export class DockerError extends Error {
+  constructor(
+    message: string,
+    public output: string,
+  ) {
+    super(message);
+  }
+}
+
+export type SdkCommand = "build" | "test";
+
+/**
+ * Run an SDK container with either its `build` or `test` command, returning
+ * the combined stdout+stderr output. Throws `DockerError` on non-zero exit.
+ *
+ * The container is always invoked with `--platform=linux/amd64`; see
+ * `docs/src/requirements.md` for context.
+ */
+export async function runSdkDocker(service: ServiceConfig, projectRoot: string, command: SdkCommand): Promise<string> {
+  const sdk = resolveSdk(service.sdk);
+  const servicePath = resolve(projectRoot, service.path);
+
+  // SDK images currently ship only linux/amd64; force the platform so that the
+  // implicit `docker pull` works on Apple Silicon and other arm64 hosts (#111).
+  const dockerArgs = [
+    "run",
+    "--rm",
+    "--platform=linux/amd64",
+    "-v",
+    `${servicePath}:/app`,
+    sdk.image,
+    ...sdk[command].split(" "),
+  ];
+  const dockerCommand = `docker ${dockerArgs.join(" ")}`;
+
+  const proc = Bun.spawn(["sh", "-c", `${dockerCommand} 2>&1`], {
+    stdout: "pipe",
+    stderr: "pipe",
+    cwd: projectRoot,
+  });
+
+  const [combinedOutput, exitCode] = await Promise.all([new Response(proc.stdout).text(), proc.exited]);
+
+  if (exitCode !== 0) {
+    const verb = command === "build" ? "Build failed" : "Tests failed";
+    throw new DockerError(`${verb} for service '${service.name}' with exit code ${exitCode}`, combinedOutput);
+  }
+
+  return combinedOutput;
+}

--- a/bin/cli/src/utils/run-sdk-docker.ts
+++ b/bin/cli/src/utils/run-sdk-docker.ts
@@ -24,12 +24,15 @@ export async function runSdkDocker(service: ServiceConfig, projectRoot: string, 
   const sdk = resolveSdk(service.sdk);
   const servicePath = resolve(projectRoot, service.path);
 
-  // SDK images currently ship only linux/amd64; force the platform so that the
-  // implicit `docker pull` works on Apple Silicon and other arm64 hosts (#111).
+  // Force a docker platform so that the implicit `docker pull` works on hosts
+  // whose native arch the image doesn't publish (e.g. amd64-only `jambrains`
+  // pulled on Apple Silicon). Defaults to `linux/amd64`; overridable per-SDK
+  // via `SdkConfig.platform`. See #111 and `docs/src/requirements.md`.
+  const platform = sdk.platform ?? "linux/amd64";
   const dockerArgs = [
     "run",
     "--rm",
-    "--platform=linux/amd64",
+    `--platform=${platform}`,
     "-v",
     `${servicePath}:/app`,
     sdk.image,

--- a/docs/src/requirements.md
+++ b/docs/src/requirements.md
@@ -40,6 +40,6 @@ Verify each tool with `bun --version`, `docker --version`, and `git --version` b
 
 ## Platform
 
-jammin always invokes the SDK build and test containers with `--platform=linux/amd64`. SDK Docker images must publish a `linux/amd64` manifest; native `arm64` (or other) manifests are ignored. On Apple Silicon and other non-amd64 hosts this means containers run under emulation (slower, but functional).
+jammin invokes the SDK build and test containers with `--platform=linux/amd64` by default. Most JAM SDK images today only publish a `linux/amd64` manifest, so on Apple Silicon and other non-amd64 hosts containers run under emulation (slower, but functional).
 
-This is a current limitation. If you are adding a new SDK in `packages/jammin-sdk/config/sdk-configs.ts`, make sure the image you reference is built for `linux/amd64`.
+If an SDK image publishes a different manifest (e.g. `linux/arm64`), override the default by setting `platform` on the `SdkConfig` entry in `packages/jammin-sdk/config/sdk-configs.ts` (or on an inline `SdkConfig` in your `jammin.build.yml`).

--- a/docs/src/requirements.md
+++ b/docs/src/requirements.md
@@ -37,3 +37,9 @@ sudo apt-get install -y git
 ```
 
 Verify each tool with `bun --version`, `docker --version`, and `git --version` before running jammin commands.
+
+## Platform
+
+jammin always invokes the SDK build and test containers with `--platform=linux/amd64`. SDK Docker images must publish a `linux/amd64` manifest; native `arm64` (or other) manifests are ignored. On Apple Silicon and other non-amd64 hosts this means containers run under emulation (slower, but functional).
+
+This is a current limitation. If you are adding a new SDK in `packages/jammin-sdk/config/sdk-configs.ts`, make sure the image you reference is built for `linux/amd64`.

--- a/packages/jammin-sdk/config/types/config.ts
+++ b/packages/jammin-sdk/config/types/config.ts
@@ -24,7 +24,11 @@ export interface ServiceConfig {
 }
 
 export interface SdkConfig {
-  /** Docker image name */
+  /**
+   * Docker image name. The image MUST publish a `linux/amd64` manifest:
+   * jammin runs build/test containers with `--platform=linux/amd64`, so
+   * native arm64 (or other) manifests are ignored. See `docs/src/requirements.md`.
+   */
   image: string;
   /** Build command */
   build: string;

--- a/packages/jammin-sdk/config/types/config.ts
+++ b/packages/jammin-sdk/config/types/config.ts
@@ -25,15 +25,20 @@ export interface ServiceConfig {
 
 export interface SdkConfig {
   /**
-   * Docker image name. The image MUST publish a `linux/amd64` manifest:
-   * jammin runs build/test containers with `--platform=linux/amd64`, so
-   * native arm64 (or other) manifests are ignored. See `docs/src/requirements.md`.
+   * Docker image name. The referenced image must publish a manifest matching
+   * `platform` (defaults to `linux/amd64`). See `docs/src/requirements.md`.
    */
   image: string;
   /** Build command */
   build: string;
   /** Test command */
   test: string;
+  /**
+   * Docker platform passed via `--platform=<value>`. Defaults to `linux/amd64`
+   * because most JAM SDK images today only ship an amd64 manifest. Override
+   * (e.g. `"linux/arm64"`) only when the image publishes a matching manifest.
+   */
+  platform?: string;
 }
 
 /** Internal: `SdkConfig` plus optional flags consumed by the resolver. */


### PR DESCRIPTION
## Summary

Fixes #111. `jammin build` (and `jammin test`) failed on Apple Silicon because the implicit `docker pull` triggered by `docker run` could not find a matching manifest for SDK images that only publish `linux/amd64` (e.g. `ghcr.io/jambrains/service-sdk`).

### Commits

1. **fix(cli):** pass `--platform=linux/amd64` to docker build/test runs (the #111 fix).
2. **docs:** document the `linux/amd64` requirement in `requirements.md` and `SdkConfig.image`.
3. **fix(cli):** also pass `--platform=linux/amd64` to `startContainer` in `start-command.ts` (defensive — `pullImage` already does, but keeping pull and run consistent removes a footgun).
4. **refactor(cli):** extract the near-identical `callDockerBuild` / `testService` into a shared `runSdkDocker` helper plus a single `DockerError` class.
5. **feat(sdk):** add optional `platform?: string` to `SdkConfig`, defaulting to `linux/amd64`. SDKs whose image publishes a different manifest can override it. Docs updated.

Commits 3–5 came out of `/reflect` and are arguably out of scope for #111 — happy to drop them or split into separate PRs if preferred.

## Test plan
- [x] `bun test` — 185 pass, 0 fail
- [x] `bun run qa` — clean
- [ ] Manually verify `jammin create` + `jammin build` succeeds on Apple Silicon (jambrains template)