### PR TITLE
feat(sdk): warn when user-defined storage utilisation differs from computed

### DIFF
--- a/packages/jammin-sdk/utils/genesis-state-generator.test.ts
+++ b/packages/jammin-sdk/utils/genesis-state-generator.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, mock, test } from "bun:test";
 import { Bytes, BytesBlob } from "@typeberry/lib/bytes";
 import { HashDictionary } from "@typeberry/lib/collections";
 import { Blake2b, HASH_SIZE } from "@typeberry/lib/hash";
@@ -198,6 +198,112 @@ describe("genesis-generator", () => {
       };
 
       expect(() => generateState([serviceWithMissingPreimage])).toThrow("Preimage blob not found for hash");
+    });
+
+    test("should not warn when user-defined storage utilisation matches computed value", async () => {
+      const warnSpy = mock(() => {});
+      const originalWarn = console.warn;
+      console.warn = warnSpy;
+      try {
+        // basicService has no storage, so computed bytes = 81 (BASE) + 94 (code) = 175, count = 2.
+        const serviceWithMatchingInfo: ServiceBuildOutput = {
+          ...basicService,
+          id: ServiceId(400),
+          info: {
+            storageUtilisationBytes: U64(175),
+            storageUtilisationCount: U32(2),
+          },
+        };
+
+        generateState([serviceWithMatchingInfo]);
+
+        expect(warnSpy).not.toHaveBeenCalled();
+      } finally {
+        console.warn = originalWarn;
+      }
+    });
+
+    test("should warn when user-defined storageUtilisationBytes differs from computed value", async () => {
+      const warnSpy = mock(() => {});
+      const originalWarn = console.warn;
+      console.warn = warnSpy;
+      try {
+        const userDefinedBytes = U64(9_999_999n);
+        const serviceWithMismatch: ServiceBuildOutput = {
+          ...basicService,
+          id: ServiceId(401),
+          info: {
+            storageUtilisationBytes: userDefinedBytes,
+          },
+        };
+
+        const state = generateState([serviceWithMismatch]);
+
+        expect(warnSpy).toHaveBeenCalledTimes(1);
+        const msg = warnSpy.mock.calls[0]?.[0] as string;
+        expect(msg).toContain("Service 401");
+        expect(msg).toContain("storageUtilisationBytes");
+        expect(msg).toContain("9999999");
+        expect(msg).toContain("175");
+
+        // User-defined value still wins.
+        const info = state.services.get(ServiceId(401))?.getInfo();
+        expect(info?.storageUtilisationBytes).toEqual(userDefinedBytes);
+      } finally {
+        console.warn = originalWarn;
+      }
+    });
+
+    test("should warn when user-defined storageUtilisationCount differs from computed value", async () => {
+      const warnSpy = mock(() => {});
+      const originalWarn = console.warn;
+      console.warn = warnSpy;
+      try {
+        const userDefinedCount = U32(42);
+        const serviceWithMismatch: ServiceBuildOutput = {
+          ...basicService,
+          id: ServiceId(402),
+          info: {
+            storageUtilisationCount: userDefinedCount,
+          },
+        };
+
+        const state = generateState([serviceWithMismatch]);
+
+        expect(warnSpy).toHaveBeenCalledTimes(1);
+        const msg = warnSpy.mock.calls[0]?.[0] as string;
+        expect(msg).toContain("Service 402");
+        expect(msg).toContain("storageUtilisationCount");
+        expect(msg).toContain("42");
+        expect(msg).toContain("(2)");
+
+        const info = state.services.get(ServiceId(402))?.getInfo();
+        expect(info?.storageUtilisationCount).toEqual(userDefinedCount);
+      } finally {
+        console.warn = originalWarn;
+      }
+    });
+
+    test("should warn for both bytes and count when both differ", async () => {
+      const warnSpy = mock(() => {});
+      const originalWarn = console.warn;
+      console.warn = warnSpy;
+      try {
+        const serviceWithMismatch: ServiceBuildOutput = {
+          ...basicService,
+          id: ServiceId(403),
+          info: {
+            storageUtilisationBytes: U64(1n),
+            storageUtilisationCount: U32(1),
+          },
+        };
+
+        generateState([serviceWithMismatch]);
+
+        expect(warnSpy).toHaveBeenCalledTimes(2);
+      } finally {
+        console.warn = originalWarn;
+      }
     });
 
     test("should calculate storage utilisation correctly with additional preimages", async () => {

--- a/packages/jammin-sdk/utils/genesis-state-generator.ts
+++ b/packages/jammin-sdk/utils/genesis-state-generator.ts
@@ -1,10 +1,10 @@
-import { Header } from "@typeberry/lib/block";
+import { Header, type ServiceId as ServiceIdType } from "@typeberry/lib/block";
 import { BytesBlob } from "@typeberry/lib/bytes";
 import { Encoder } from "@typeberry/lib/codec";
 import { tinyChainSpec } from "@typeberry/lib/config";
 import { JipChainSpec } from "@typeberry/lib/config-node";
 import { Blake2b, ZERO_HASH } from "@typeberry/lib/hash";
-import { sumU32, sumU64 } from "@typeberry/lib/numbers";
+import { sumU32, sumU64, type U32 as U32Type, type U64 as U64Type } from "@typeberry/lib/numbers";
 import {
   InMemoryState,
   LookupHistoryItem,
@@ -183,6 +183,8 @@ export function generateState(services: ServiceBuildOutput[]): InMemoryState {
       }
     }
 
+    warnOnStorageUtilisationMismatch(serviceId, service.info, calculatedStorageBytes, calculatedStorageCount);
+
     // create service
     update.updated?.set(
       serviceId,
@@ -202,6 +204,35 @@ export function generateState(services: ServiceBuildOutput[]): InMemoryState {
   memState.applyUpdate(update);
 
   return memState;
+}
+
+/**
+ * Print a notice when the user-defined storage utilisation values do not match
+ * the values computed from preimages and storage items. The user-defined value
+ * takes precedence — this only logs both numbers so the user can spot
+ * discrepancies.
+ */
+function warnOnStorageUtilisationMismatch(
+  serviceId: ServiceIdType,
+  info: ServiceBuildOutput["info"],
+  calculatedStorageBytes: U64Type,
+  calculatedStorageCount: U32Type,
+): void {
+  const userBytes = info?.storageUtilisationBytes;
+  if (userBytes !== undefined && userBytes !== calculatedStorageBytes) {
+    console.warn(
+      `[jammin] Service ${serviceId}: user-defined storageUtilisationBytes (${userBytes}) ` +
+        `differs from computed value (${calculatedStorageBytes}). Using user-defined value.`,
+    );
+  }
+
+  const userCount = info?.storageUtilisationCount;
+  if (userCount !== undefined && userCount !== calculatedStorageCount) {
+    console.warn(
+      `[jammin] Service ${serviceId}: user-defined storageUtilisationCount (${userCount}) ` +
+        `differs from computed value (${calculatedStorageCount}). Using user-defined value.`,
+    );
+  }
 }
 
 /** Creates a new genesis state with provided services */


### PR DESCRIPTION
Resolves #96.

## Summary

- When a service config sets `storage_utilisation_bytes` or `storage_utilisation_count` explicitly, the user-provided value still wins over the value computed from preimages and storage items (existing behavior).
- Add a `console.warn` per mismatched field that shows both the user-defined and the computed value side by side, so accidental mismatches are visible.
- Matches the existing SDK warning pattern (`[jammin]` prefix used in `sdk-configs.ts` and `simulator.ts`). The issue explicitly notes that wiring `genesis-state-generator` back to a typeberry logger is out of scope here.

Sample output:
```
[jammin] Service 401: user-defined storageUtilisationBytes (9999999) differs from computed value (175). Using user-defined value.
```

## Test plan

- [x] `bun run build`
- [x] `bun run qa`
- [x] `bun test` (189 pass, 0 fail)
- [x] Added unit tests covering: matching values (no warn), bytes mismatch only, count mismatch only, both mismatched. Each asserts the user-defined value still wins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)