### PR TITLE
feat(sdk): load TestJam state from JIP-4 genesis.json

### DIFF
--- a/packages/jammin-sdk/simulator.test.ts
+++ b/packages/jammin-sdk/simulator.test.ts
@@ -173,12 +173,9 @@ describe("TestJam.fromGenesis", () => {
     return {
       id: genesis.id,
       bootnodes: genesis.bootnodes ?? [],
-      genesis_header: genesis.genesisHeader.toString().substring(2),
+      genesis_header: genesis.genesisHeader.toString().slice(2),
       genesis_state: Object.fromEntries(
-        [...genesis.genesisState.entries()].map(([key, value]) => [
-          key.toString().substring(2),
-          value.toString().substring(2),
-        ]),
+        [...genesis.genesisState.entries()].map(([key, value]) => [key.toString().slice(2), value.toString().slice(2)]),
       ),
     };
   }

--- a/packages/jammin-sdk/simulator.test.ts
+++ b/packages/jammin-sdk/simulator.test.ts
@@ -212,4 +212,27 @@ describe("TestJam.fromGenesis", () => {
       `Genesis file not found at ${missingPath}. Run 'jammin deploy' first.`,
     );
   });
+
+  test("accumulate() runs against state loaded from a genesis file", async () => {
+    const genesis = generateGenesis([]);
+    const tmpDir = join(tmpdir(), `jammin-acc-${Date.now()}`);
+    await mkdir(tmpDir, { recursive: true });
+    const tmpPath = join(tmpDir, "genesis.json");
+    await Bun.write(tmpPath, JSON.stringify(toJip4Json(genesis)));
+
+    try {
+      const jam = await TestJam.fromGenesis(tmpPath);
+      const report = await createWorkReportAsync({
+        results: [{ serviceId: ServiceId(0), gas: Gas(1000n) }],
+      });
+
+      const result = await jam.withWorkReport(report).accumulate();
+
+      expect(result).toBeDefined();
+      expect(result.stateUpdate).toBeDefined();
+      expect(result.accumulationStatistics.size).toBe(1);
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
 });

--- a/packages/jammin-sdk/simulator.test.ts
+++ b/packages/jammin-sdk/simulator.test.ts
@@ -1,5 +1,6 @@
 import { beforeAll, describe, expect, test } from "bun:test";
 import * as config from "@typeberry/lib/config";
+import { SerializedState } from "@typeberry/lib/state-merkleization";
 import { generateGuarantees, TestJam } from "./simulator.js";
 import { CoreId, Gas, ServiceId, Slot } from "./types.js";
 import { createWorkReportAsync } from "./work-report.js";
@@ -151,5 +152,12 @@ describe("generateGuarantees", () => {
     const indices = guarantees[0]?.credentials.map((c) => Number(c.validatorIndex)) ?? [];
     expect(indices[0]).toBeLessThan(indices[1] ?? 0);
     expect(indices[1]).toBeLessThan(indices[2] ?? 0);
+  });
+});
+
+describe("TestJam factory state shape", () => {
+  test("TestJam.empty() holds SerializedState at runtime", () => {
+    const jam = TestJam.empty();
+    expect(jam.state).toBeInstanceOf(SerializedState);
   });
 });

--- a/packages/jammin-sdk/simulator.test.ts
+++ b/packages/jammin-sdk/simulator.test.ts
@@ -1,8 +1,13 @@
 import { beforeAll, describe, expect, test } from "bun:test";
+import { mkdir, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { BytesBlob } from "@typeberry/lib/bytes";
 import * as config from "@typeberry/lib/config";
 import { SerializedState } from "@typeberry/lib/state-merkleization";
 import { generateGuarantees, TestJam } from "./simulator.js";
 import { CoreId, Gas, ServiceId, Slot } from "./types.js";
+import { generateGenesis } from "./utils/index.js";
 import { createWorkReportAsync } from "./work-report.js";
 
 describe("simulateAccumulation", () => {
@@ -159,5 +164,52 @@ describe("TestJam factory state shape", () => {
   test("TestJam.empty() holds SerializedState at runtime", () => {
     const jam = TestJam.empty();
     expect(jam.state).toBeInstanceOf(SerializedState);
+  });
+});
+
+describe("TestJam.fromGenesis", () => {
+  // Serialise a JipChainSpec to the JIP-4 JSON shape (hex-encoded keys/values).
+  function toJip4Json(genesis: ReturnType<typeof generateGenesis>) {
+    return {
+      id: genesis.id,
+      bootnodes: genesis.bootnodes ?? [],
+      genesis_header: genesis.genesisHeader.toString().substring(2),
+      genesis_state: Object.fromEntries(
+        [...genesis.genesisState.entries()].map(([key, value]) => [
+          key.toString().substring(2),
+          value.toString().substring(2),
+        ]),
+      ),
+    };
+  }
+
+  test("loads state from a written genesis.json file", async () => {
+    const service = {
+      id: ServiceId(7),
+      code: BytesBlob.parseBlob("0xdeadbeef"),
+    };
+    const genesis = generateGenesis([service]);
+
+    const tmpDir = join(tmpdir(), `jammin-test-${Date.now()}`);
+    await mkdir(tmpDir, { recursive: true });
+    const tmpPath = join(tmpDir, "genesis.json");
+    await Bun.write(tmpPath, JSON.stringify(toJip4Json(genesis)));
+
+    try {
+      const jam = await TestJam.fromGenesis(tmpPath);
+      expect(jam.state).toBeInstanceOf(SerializedState);
+
+      const info = jam.getServiceInfo(ServiceId(7));
+      expect(info).toBeDefined();
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  test("throws a clear error when the genesis file is missing", async () => {
+    const missingPath = join(tmpdir(), `definitely-not-here-${Date.now()}.json`);
+    await expect(TestJam.fromGenesis(missingPath)).rejects.toThrow(
+      `Genesis file not found at ${missingPath}. Run 'jammin deploy' first.`,
+    );
   });
 });

--- a/packages/jammin-sdk/simulator.ts
+++ b/packages/jammin-sdk/simulator.ts
@@ -18,7 +18,7 @@ import {
 import { asOpaqueType } from "@typeberry/lib/utils";
 import { loadBuildConfig } from "./config/config-loader.js";
 import { Slot } from "./types.js";
-import { generateState, loadServices } from "./utils/index.js";
+import { generateGenesis, loadServices, loadStateFromGenesis } from "./utils/index.js";
 import type { WorkReport } from "./work-report.js";
 
 // Re-export types for convenience
@@ -345,8 +345,8 @@ export class TestJam {
    */
   static async create(): Promise<TestJam> {
     const config = await loadBuildConfig();
-    const state = generateState(await loadServices(config));
-    return new TestJam(state);
+    const genesis = generateGenesis(await loadServices(config));
+    return new TestJam(loadStateFromGenesis(genesis));
   }
 
   /**
@@ -361,8 +361,7 @@ export class TestJam {
    * ```
    */
   static empty(): TestJam {
-    const state = generateState([]);
-    return new TestJam(state);
+    return new TestJam(loadStateFromGenesis(generateGenesis([])));
   }
 
   /**

--- a/packages/jammin-sdk/simulator.ts
+++ b/packages/jammin-sdk/simulator.ts
@@ -387,7 +387,7 @@ export class TestJam {
     if (!(await file.exists())) {
       throw new Error(`Genesis file not found at ${path}. Run 'jammin deploy' first.`);
     }
-    const genesis = parseFromJson(JSON.parse(await file.text()), JipChainSpec.fromJson);
+    const genesis = parseFromJson<JipChainSpec>(JSON.parse(await file.text()), JipChainSpec.fromJson);
     return new TestJam(loadStateFromGenesis(genesis));
   }
 

--- a/packages/jammin-sdk/simulator.ts
+++ b/packages/jammin-sdk/simulator.ts
@@ -4,8 +4,10 @@ import { BytesBlob } from "@typeberry/lib/bytes";
 import { Encoder } from "@typeberry/lib/codec";
 import { asKnownSize } from "@typeberry/lib/collections";
 import { type ChainSpec, PvmBackend, tinyChainSpec } from "@typeberry/lib/config";
+import { JipChainSpec } from "@typeberry/lib/config-node";
 import { ed25519, keyDerivation } from "@typeberry/lib/crypto";
 import { Blake2b, type OpaqueHash, ZERO_HASH } from "@typeberry/lib/hash";
+import { parseFromJson } from "@typeberry/lib/json-parser";
 import * as jamNumbers from "@typeberry/lib/numbers";
 import { InMemoryState, type LookupHistorySlots, type ServiceAccountInfo, type State } from "@typeberry/lib/state";
 import { type SerializedState, type StateEntries, serializeStateUpdate } from "@typeberry/lib/state-merkleization";
@@ -362,6 +364,31 @@ export class TestJam {
    */
   static empty(): TestJam {
     return new TestJam(loadStateFromGenesis(generateGenesis([])));
+  }
+
+  /**
+   * Create a new TestJam instance with state loaded from a JIP-4 genesis file.
+   *
+   * @param path - Path to the genesis.json file. Defaults to `./dist/genesis.json`.
+   * @returns Promise resolving to a new TestJam instance with state loaded from the file.
+   * @throws If the file is missing, malformed JSON, or doesn't match the JIP-4 schema.
+   *
+   * @example
+   * ```typescript
+   * // After running `jammin deploy`:
+   * const jam = await TestJam.fromGenesis();
+   *
+   * // Or from an explicit path:
+   * const jam = await TestJam.fromGenesis("./fixtures/genesis.json");
+   * ```
+   */
+  static async fromGenesis(path = "./dist/genesis.json"): Promise<TestJam> {
+    const file = Bun.file(path);
+    if (!(await file.exists())) {
+      throw new Error(`Genesis file not found at ${path}. Run 'jammin deploy' first.`);
+    }
+    const genesis = parseFromJson(JSON.parse(await file.text()), JipChainSpec.fromJson);
+    return new TestJam(loadStateFromGenesis(genesis));
   }
 
   /**

--- a/packages/jammin-sdk/utils/genesis-state-generator.test.ts
+++ b/packages/jammin-sdk/utils/genesis-state-generator.test.ts
@@ -6,7 +6,7 @@ import { type StorageKey, tryAsLookupHistorySlots } from "@typeberry/lib/state";
 import { asOpaqueType } from "@typeberry/lib/utils";
 import { Gas, ServiceId, Slot, U32, U64 } from "../types";
 import type { ServiceBuildOutput } from "./generate-service-output";
-import { generateGenesis, generateState, toJip4Schema } from "./genesis-state-generator";
+import { generateGenesis, generateState, loadStateFromGenesis, toJip4Schema } from "./genesis-state-generator";
 
 const blake2b = await Blake2b.createHasher();
 
@@ -328,6 +328,67 @@ describe("genesis-generator", () => {
 
       expect(info?.storageUtilisationCount).toBe(U32(4));
       expect(info?.storageUtilisationBytes).toEqual(U64(260));
+    });
+  });
+
+  describe("loadStateFromGenesis", () => {
+    test("round-trips a service code blob via genesis serialisation", () => {
+      const genesis = generateGenesis([basicService]);
+      const state = loadStateFromGenesis(genesis);
+
+      const service = state.getService(ServiceId(42));
+      expect(service).not.toBeNull();
+
+      const codeHash = blake2b.hashBytes(basicService.code).asOpaque();
+      expect(service?.getInfo().codeHash.toString()).toBe(codeHash.toString());
+    });
+
+    test("round-trips service storage entries", () => {
+      const storageKeyStr = "key1";
+      const storageValueStr = "value1";
+
+      const serviceWithStorage: ServiceBuildOutput = {
+        ...basicService,
+        id: ServiceId(100),
+        storage: { [storageKeyStr]: storageValueStr },
+      };
+
+      const genesis = generateGenesis([serviceWithStorage]);
+      const state = loadStateFromGenesis(genesis);
+
+      const service = state.getService(ServiceId(100));
+      expect(service).not.toBeNull();
+
+      const storageKey: StorageKey = asOpaqueType(BytesBlob.blobFromString(storageKeyStr));
+      const retrieved = service?.getStorage(storageKey);
+      expect(retrieved?.toString()).toBe(BytesBlob.blobFromString(storageValueStr).toString());
+    });
+
+    test("round-trips preimage blobs", () => {
+      const preimageBlob = BytesBlob.parseBlob("0xaabbccdd");
+      const preimageHash = blake2b.hashBytes(preimageBlob).asOpaque();
+
+      const serviceWithPreimage: ServiceBuildOutput = {
+        ...basicService,
+        id: ServiceId(300),
+        preimageBlobs: HashDictionary.fromEntries([[preimageHash, preimageBlob]]),
+        preimageRequests: new Map([[preimageHash, tryAsLookupHistorySlots([Slot(0)])]]),
+      };
+
+      const genesis = generateGenesis([serviceWithPreimage]);
+      const state = loadStateFromGenesis(genesis);
+
+      const service = state.getService(ServiceId(300));
+      expect(service).not.toBeNull();
+      expect(service?.getPreimage(preimageHash)?.toString()).toBe(preimageBlob.toString());
+    });
+
+    test("round-trips an empty genesis with no services", () => {
+      const genesis = generateGenesis([]);
+      const state = loadStateFromGenesis(genesis);
+
+      expect(state.getService(ServiceId(0))).toBeNull();
+      expect(state.getService(ServiceId(42))).toBeNull();
     });
   });
 });

--- a/packages/jammin-sdk/utils/genesis-state-generator.ts
+++ b/packages/jammin-sdk/utils/genesis-state-generator.ts
@@ -19,7 +19,7 @@ import {
   UpdateService,
   UpdateStorage,
 } from "@typeberry/lib/state";
-import { StateEntries } from "@typeberry/lib/state-merkleization";
+import { loadState, type SerializedState, StateEntries } from "@typeberry/lib/state-merkleization";
 import { asOpaqueType } from "@typeberry/lib/utils";
 import { Gas, ServiceId, Slot, U32, U64 } from "../types.js";
 import type { ServiceBuildOutput } from "./generate-service-output.js";
@@ -244,4 +244,9 @@ export function generateGenesis(services: ServiceBuildOutput[]): Genesis {
     genesisHeader: Encoder.encodeObject(Header.Codec, Header.empty(), spec),
     genesisState: new Map(Array.from(state.entries())),
   });
+}
+
+/** Load the SDK state from a parsed JIP-4 chain spec. */
+export function loadStateFromGenesis(genesis: Genesis): SerializedState<StateEntries> {
+  return loadState(spec, blake2b, genesis.genesisState.entries());
 }


### PR DESCRIPTION
## Summary

- Add `loadStateFromGenesis(genesis)` SDK primitive that materialises a `SerializedState<StateEntries>` from a parsed JIP-4 `JipChainSpec` — the inverse of `generateGenesis`, and a thin wrapper over typeberry's `state_merkleization.loadState`.
- Route `TestJam.create()` and `TestJam.empty()` through the new primitive. `TestJam.state` now holds `SerializedState<StateEntries>` at runtime — the **same** state shape typeberry consumes when it loads `genesis.json` at deploy time, instead of the hand-rolled `InMemoryState` that mirrored JAM service-account semantics in `generateState`. Any drift between SDK construction and typeberry's deserialiser now surfaces in tests, not at `jammin deploy && jammin start`.
- New factory `TestJam.fromGenesis(path?: string)` reads a JIP-4 file from disk, defaults to `./dist/genesis.json` so it "just works" after a `jammin deploy`. Missing files throw with a clear hint to run `jammin deploy` first; malformed JSON / schema errors propagate unmodified from `JSON.parse` / `parseFromJson`.

Closes #104.

## Behaviour change to flag

`TestJam.state` previously held `InMemoryState`; it now holds `SerializedState<StateEntries>` for instances built via `create()` and `empty()` (and the new `fromGenesis()`). The declared type union is unchanged. `accumulate()` already branched on both shapes, so no consumer changes are required unless code was narrowing `jam.state instanceof InMemoryState` directly.

## Spec & plan

- Design: `docs/superpowers/specs/2026-05-17-load-sdk-state-from-genesis-design.md` (gitignored — workflow artefact only)
- Plan: `docs/superpowers/plans/2026-05-17-load-sdk-state-from-genesis.md` (gitignored — workflow artefact only)

## Test plan

- [x] `bun test packages/jammin-sdk` — 163 SDK tests pass (4 new round-trip tests for `loadStateFromGenesis`; 1 state-shape test for `TestJam.empty()`; 3 new tests for `TestJam.fromGenesis()` covering happy path, missing-file error, and an `accumulate()` regression).
- [x] `bun test` — full suite (SDK + CLI), 193 pass / 0 fail / 1 skip across 14 files.
- [x] `bun run build` — clean build, no TS errors.
- [x] `bun run qa` — Biome clean.
- [x] Public-surface smoke check: `loadStateFromGenesis`, `TestJam.fromGenesis`, `TestJam.empty`, `TestJam.create` all reachable through `packages/jammin-sdk/dist/index.js`.

## Out of scope

- Changing the on-disk JIP-4 schema or the `jammin deploy` flow.
- Touching `jammin start` or the Docker-based local network.
- Removing or rewriting `generateState` / `generateGenesis` — they remain the way `jammin deploy` produces the file in the first place.
- Schema validation of the loaded `genesis.json` beyond what `JipChainSpec.fromJson` already does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)